### PR TITLE
ci(20): add workflow_dispatch to publish.yml — Phase 20 E2E-01 recovery

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,18 @@ name: Publish to PyPI.org
 on:
   release:
     types: [published]
+  # workflow_dispatch added 2026-05-20 (Phase 20 E2E-01 recovery): when a
+  # release is created by another workflow (e.g. beta-release.yml) using a
+  # PAT that lacks `workflow` scope, GitHub suppresses the release.published
+  # event from triggering downstream workflows. This manual trigger lets
+  # the operator re-publish to PyPI for a specific tag without modifying
+  # the stable-path automatic trigger above.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish to PyPI (e.g. 3.0.0b1, 2.0.7).'
+        required: true
+        type: string
 jobs:
   pypi:
     runs-on: ubuntu-latest
@@ -10,6 +22,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # For workflow_dispatch: check out the specified tag.
+          # For release: published: leave default (the release's commit).
+          ref: ${{ github.event.inputs.tag || github.ref }}
       - run: python3 -m pip install --upgrade build && python3 -m build
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` to `.github/workflows/publish.yml` so the operator can manually re-publish a tag to PyPI when the automatic `release.published` trigger is suppressed.
- Suppression happens when a Release is created by another workflow (e.g. `beta-release.yml`) using a PAT that lacks the `workflow` OAuth scope — GitHub will not fire dependent workflow triggers in that path.
- Stable-path `release: published` trigger is untouched.

## Why now
First v1.4 beta cut (3.0.0b1) created the GitHub Pre-release successfully but `publish.yml` did not fire. This PR is the recovery substrate so the operator can run `gh workflow run publish.yml -f tag=3.0.0b1` and complete the v1.4 E2E.

## Test plan
- [ ] Merge → confirm `publish.yml` on `main` now shows the manual-run button in the Actions UI
- [ ] `gh workflow run publish.yml -f tag=3.0.0b1 --ref 3.0.0b1` completes successfully
- [ ] PyPI receives `firestarter-3.0.0b1` (verify at https://pypi.org/project/firestarter/#history)

🤖 Generated with [Claude Code](https://claude.com/claude-code)