### PR TITLE
Centralize issue tracking in firestarter_prom

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Central Firestarter issue tracker
+    url: https://github.com/henols/firestarter_prom/issues/new/choose
+    about: Report bugs, request features, ask for support, or coordinate cross-repository work here.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,10 @@
+# Firestarter support and issue tracking
+
+Bugs, feature requests, support requests, release coordination, and cross-repository work are tracked centrally in [`henols/firestarter_prom`](https://github.com/henols/firestarter_prom/issues).
+
+Please do not open project issues in this repository. Use the central issue tracker instead:
+
+- [Open a Firestarter issue](https://github.com/henols/firestarter_prom/issues/new/choose)
+- [Browse existing Firestarter issues](https://github.com/henols/firestarter_prom/issues)
+
+For community discussion, you can also use the [Firestarter Discord server](https://discord.com/invite/kmhbxAjQc3).


### PR DESCRIPTION
Implements the `firestarter_app` documentation and issue-routing portion of henols/firestarter_prom#6:

- adds `.github/ISSUE_TEMPLATE/config.yml` that disables local blank issue creation and redirects users to the canonical `henols/firestarter_prom` tracker
- adds `SUPPORT.md` with clear links for bugs, feature requests, support, firmware issues, and cross-repository work

Repository-level disabling of GitHub Issues and `main` branch protection still require repository admin settings.