### PR TITLE
fix(database): use configure_flash3 for ASD AE29Fxxxx flash chips

### DIFF
--- a/firestarter/data/chip_database.json
+++ b/firestarter/data/chip_database.json
@@ -1223,7 +1223,7 @@
       "part_number": "AE29F1008",
       "pinout": "DIP32_SST39SF040",
       "programming": {
-        "algorithm": 5,
+        "algorithm": 6,
         "chip_id_check": true,
         "chip_id_value": "0x0000dac1",
         "pulse_duration": "Algorithm Controlled"
@@ -1243,7 +1243,7 @@
       "part_number": "AE29F2008",
       "pinout": "DIP32_SST39SF040",
       "programming": {
-        "algorithm": 5,
+        "algorithm": 6,
         "chip_id_check": true,
         "chip_id_value": "0x0000da45",
         "pulse_duration": "Algorithm Controlled"
@@ -1263,7 +1263,7 @@
       "part_number": "AE29F4008",
       "pinout": "DIP32_SST39SF040",
       "programming": {
-        "algorithm": 5,
+        "algorithm": 6,
         "chip_id_check": true,
         "chip_id_value": "0x0000da46",
         "pulse_duration": "Algorithm Controlled"


### PR DESCRIPTION
AE29F1008, AE29F2008, and AE29F4008 use the AMD command set but were routed to configure_flash4 (algorithm 5, hardware VPP pulse) instead of configure_flash3 (algorithm 6, 6-byte software erase). This caused erase to silently fail the blank check. AE49F2008 from the same manufacturer already correctly uses algorithm 6.

Confirmed fix works on AE29F2008 with a RURP shield on Arduino Uno.