### PR TITLE
fix(build_db): Rule 4 — ASD AE29F-series requires configure_flash3 (algo 0x06)

### DIFF
--- a/firestarter/data/chip_database.json
+++ b/firestarter/data/chip_database.json
@@ -1223,7 +1223,7 @@
       "part_number": "AE29F1008",
       "pinout": "DIP32_SST39SF040",
       "programming": {
-        "algorithm": 5,
+        "algorithm": 6,
         "chip_id_check": true,
         "chip_id_value": "0x0000dac1",
         "pulse_duration": "Algorithm Controlled"
@@ -1243,7 +1243,7 @@
       "part_number": "AE29F2008",
       "pinout": "DIP32_SST39SF040",
       "programming": {
-        "algorithm": 5,
+        "algorithm": 6,
         "chip_id_check": true,
         "chip_id_value": "0x0000da45",
         "pulse_duration": "Algorithm Controlled"
@@ -1263,7 +1263,7 @@
       "part_number": "AE29F4008",
       "pinout": "DIP32_SST39SF040",
       "programming": {
-        "algorithm": 5,
+        "algorithm": 6,
         "chip_id_check": true,
         "chip_id_value": "0x0000da46",
         "pulse_duration": "Algorithm Controlled"

--- a/tools/build_db.py
+++ b/tools/build_db.py
@@ -670,6 +670,21 @@ def main():
                     # else: leave _support_status as "supported" — M2732A (21V)
                     # is within the RURP ceiling.
 
+                # Rule 4 — ASD AE29F-series algorithm correction.
+                # Upstream infoic.xml assigns protocol_id=0x05 (FLASH_AMD_STD /
+                # IC2_ALG_F29EE -> configure_flash4) to these chips, but they
+                # require algorithm 0x06 (FLASH_AMD_ALT / IC2_ALG_W29F32P ->
+                # configure_flash3) for correct AMD command-set erase.
+                # AE49F2008 from the same manufacturer already uses 0x06.
+                _ALGO4_TARGETS = {"AE29F1008", "AE29F2008", "AE29F4008"}
+                if part_aliases & _ALGO4_TARGETS and proto_id == 0x05:
+                    print(
+                        f"INFO: {mfg_name}/{name} algorithm 0x{proto_id:02X}->0x06 "
+                        f"(Rule 4: ASD AE29F-series requires configure_flash3)",
+                        file=sys.stderr,
+                    )
+                    proto_id = 0x06
+
                 chip_entry = {
                     # Upstream `name` is a comma-separated alias list where each
                     # alias may carry an @PACKAGE suffix (e.g.,


### PR DESCRIPTION
AE29F1008, AE29F2008, and AE29F4008 use the AMD command set for erase which requires the 6-byte software unlock sequence (configure_flash3 / algorithm 0x06). Upstream infoic.xml assigns algorithm 0x05 (FLASH_AMD_STD / configure_flash4) which sends a hardware VPP pulse these chips ignore, causing erase to silently fail the blank check.

**Changes:**
- `tools/build_db.py`: Added Rule 4 (alongside existing Rules 1-3) to flip proto_id 0x05->0x06 for AE29F1008/2008/4008
- `firestarter/data/chip_database.json`: Updated algorithm 5->6 for all three chips

AE49F2008 from the same manufacturer already correctly uses algorithm 0x06 upstream.

Confirmed fix works on AE29F2008 with a RURP shield on Arduino Uno.