### PR TITLE
feat(safety): refuse pre-Rev-2.2 shields for VPP-on-line-11 chips (CAP-02)

### DIFF
--- a/firestarter/chip_test.py
+++ b/firestarter/chip_test.py
@@ -51,6 +51,7 @@ from firestarter.exceptions import (
     EpromOperationError,
     FirmwareOutdatedError,
     HardwareOperationError,
+    HardwareRevisionUnsupportedError,
     ProgrammerNotFoundError,
     SerialError,
 )
@@ -1515,10 +1516,15 @@ def _run_step(
         return _dispatch_step(
             name, step, eprom_data, operator, runs=runs, sampler=sampler
         )
-    except (ProgrammerNotFoundError, FirmwareOutdatedError):
-        # D-08/LEG-11: these two SerialError subclasses are run-fatal
+    except (
+        ProgrammerNotFoundError,
+        FirmwareOutdatedError,
+        HardwareRevisionUnsupportedError,
+    ):
+        # D-08/LEG-11: these SerialError subclasses are run-fatal
         # host-setup conditions ("no programmer attached", "firmware too
-        # old"), not chip findings -- they belong to cli_handlers.py's
+        # old", "shield revision cannot safely drive this chip"), not chip
+        # findings -- they belong to cli_handlers.py's
         # @map_typed_errors mapper, which already renders them as
         # ClickExceptions with stable exit codes. This clause MUST precede
         # the (SerialError, HardwareOperationError) clause below: both are

--- a/firestarter/exceptions.py
+++ b/firestarter/exceptions.py
@@ -34,6 +34,29 @@ class FirmwareOutdatedError(SerialError):
     pass
 
 
+class HardwareRevisionUnsupportedError(SerialError):
+    """Raised when the attached shield revision cannot safely program the chip.
+
+    Chips whose bus-config routes VPP to bus line 11 (socket pin 21 on the
+    DIP24_2716 / DIP24_2532 pinouts) need the 3-position JP4 header introduced
+    on RURP Rev 2.2. Driving them on an earlier shield is a chip-damage path,
+    so the host refuses at connect time — before the operation-setup ack is
+    answered and therefore before the firmware engages the VPP regulator.
+
+    A SerialError subclass so callers already handling connect-time transport
+    failures see it, but _probe_port catches it explicitly and re-raises rather
+    than degrading it to "no programmer found" (an operator staring at a board
+    that is plainly attached needs the real reason).
+
+    `detected` carries the effective revision byte the firmware reported, or
+    None when the firmware predates the CAP-02 ack and sent no revision at all.
+    """
+
+    def __init__(self, *args: object, detected: int | None = None) -> None:
+        super().__init__(*args)
+        self.detected = detected
+
+
 class EpromOperationError(Exception):
     """Custom exception for EPROM operation failures."""
 

--- a/firestarter/serial_comm.py
+++ b/firestarter/serial_comm.py
@@ -31,9 +31,12 @@ from firestarter.constants import (
     FLAG_SKIP_BLANK_CHECK,
     FLAG_SKIP_ERASE,
     FLAG_VPE_AS_VPP,
+    REVISION_2_2,
+    REVISION_2_3,
 )
 from firestarter.exceptions import (
     FirmwareOutdatedError,
+    HardwareRevisionUnsupportedError,
     ProgrammerNotFoundError,
     ProtocolNotImplementedError,
     SerialError,
@@ -98,6 +101,17 @@ class SerialCommunicator:
     across available serial ports.
     """
 
+    # CAP-02 identity fields, declared at CLASS level on purpose. __init__ also
+    # assigns them, but plenty of call sites never run __init__ — conftest's
+    # make_comm builds instances via __new__, and several suites patch __init__
+    # to a no-op lambda to avoid opening a real port. _probe_port reads
+    # firmware_identity unconditionally, so an instance-only attribute turns
+    # every one of those into an AttributeError swallowed by the broad
+    # `except Exception` in _probe_port, which degrades to "no programmer
+    # found". Class defaults of None keep the gates fail-closed instead.
+    firmware_identity: Optional[str] = None
+    hw_revision: Optional[int] = None
+
     def __init__(
         self,
         port: str,
@@ -124,6 +138,19 @@ class SerialCommunicator:
         # with a 2-byte param is decoded. _calculate_buffer_size returns 512 (safe
         # Uno floor) when None (Phase 54 D-05 reversed; no FirmwareOutdatedError).
         self.firmware_max_chunk: Optional[int] = None
+        # CAP-02: the MSG_OK_READY ack was extended past CAP-01's 2-byte
+        # buffer-size region to also carry the effective hardware revision and
+        # the firmware identity string, so a single command exchange now yields
+        # everything the connect-time gates need. Both stay None against
+        # firmware that predates CAP-02 (2-byte ack) — and None is a REJECT for
+        # the revision gate, never a pass. Populated by _decode_id_frame below.
+        #
+        # firmware_identity is the raw "<version>:<board>" string, matching what
+        # the retired CMD_FW_VERSION probe used to read off the wire; callers
+        # wanting the numeric part must strip the board suffix exactly as
+        # _probe_port does.
+        self.firmware_identity: Optional[str] = None
+        self.hw_revision: Optional[int] = None
         # D-15 (Phase 120 / v1.22 HOST-06): bounded record of every id frame
         # successfully decoded on this connection. Populated by the
         # _decode_id_frame override below. A set of integers only — nothing
@@ -321,14 +348,32 @@ class SerialCommunicator:
             self.seen_message_ids.add(msg_id)
             if msg_id == MSG_OK_READY:
                 params_bytes = body[1:-1]  # strip id byte and trailing CRC
-                if len(params_bytes) == 2:
-                    value = struct.unpack(">H", params_bytes)[0]
+                # CAP-01 buffer size occupies the first 2 bytes in BOTH the
+                # legacy 2-byte ack and the CAP-02 extended ack, so the length
+                # test is >= 2 rather than == 2. Against CAP-02 firmware the
+                # old == 2 form silently skipped this and fell back to the 512
+                # floor; widening it is what restores full-size chunking.
+                if len(params_bytes) >= 2:
+                    value = struct.unpack(">H", params_bytes[:2])[0]
                     # Plausibility clamp: reject values outside [1, 4096].
                     # No real board exceeds the 1024-byte Leonardo buffer; 4096
                     # is a generous ceiling. Values outside this range leave
                     # firmware_max_chunk unset so the 512 floor applies (T-55-06).
                     if 1 <= value <= 4096:
                         self.firmware_max_chunk = value
+                # CAP-02 tail: [hw_revision u8][ver_len u8][ver bytes]. Absent
+                # on pre-CAP-02 firmware, which leaves both attributes None —
+                # and None is a reject for the revision gate, never a pass.
+                # A truncated or malformed length prefix also leaves
+                # firmware_identity None rather than yielding a partial string,
+                # so a mangled ack degrades to "refuse", not to "probably fine".
+                if len(params_bytes) >= 4:
+                    self.hw_revision = params_bytes[2]
+                    ver_end = 4 + params_bytes[3]
+                    if ver_end <= len(params_bytes):
+                        self.firmware_identity = params_bytes[4:ver_end].decode(
+                            "ascii", errors="replace"
+                        )
         return result
 
     # =================================================================
@@ -645,6 +690,62 @@ class SerialCommunicator:
                 f"Please upgrade the firmware using 'firestarter fw --install'."  # noqa: E501
             )
 
+    # Bus line 11 is where socket pin 21 lands on the 24-pin RURP wiring, and
+    # it is the VPP line for exactly two pinouts — DIP24_2716 and DIP24_2532.
+    # Those parts need the 3-position JP4 header introduced on shield Rev 2.2;
+    # driving them on an earlier board is a chip-damage path.
+    _VPP_LINE_REQUIRING_REV_2_2 = 11
+    # ALLOWLIST, deliberately not a `>=` comparison. The REVISION_* bytes are
+    # not a version-ordered scale: REVISION_UNKNOWN is 0xFE, numerically ABOVE
+    # REVISION_2_2 (0x04), so `detected >= REVISION_2_2` would admit precisely
+    # the boards whose revision could not be determined. Membership fails
+    # closed for 0xFE, for the 0xFF override-absent sentinel, for the
+    # REVISION_2_0 broad bucket, and for None (pre-CAP-02 firmware).
+    _REVISIONS_WITH_3_POSITION_JP4 = (REVISION_2_2, REVISION_2_3)
+
+    @staticmethod
+    def _validate_hardware_revision(
+        command_to_send: dict, detected: Optional[int]
+    ) -> None:
+        """Pure-policy shield-revision guard. Raises on reject, returns on pass.
+
+        Mirrors _validate_firmware_version's shape: no I/O, no environment
+        reads, no serial access — just the wire dict the host is about to act
+        on and the revision byte the firmware reported. That makes the policy
+        testable without a board and keeps _probe_port free of the reasoning.
+
+        Only chips whose bus-config routes VPP to bus line 11 are gated; every
+        other chip passes through untouched regardless of shield revision.
+
+        Note for operators hitting this: ADC detection collapses Rev 2.0, 2.1
+        and 2.2 into the single REVISION_2_0 bucket, so a genuine Rev 2.2 board
+        reports as 2.0-class until the EEPROM override is written. That is the
+        intended design — the operator has to look at the physical header and
+        assert it, and asserting it is the safety mechanism, not a workaround.
+        """
+        bus_config = command_to_send.get("bus-config") or {}
+        if bus_config.get("vpp-pin") != SerialCommunicator._VPP_LINE_REQUIRING_REV_2_2:
+            return
+        if detected in SerialCommunicator._REVISIONS_WITH_3_POSITION_JP4:
+            return
+
+        if detected is None:
+            reported = "nothing (firmware predates the revision-carrying ack)"
+        else:
+            reported = f"0x{detected:02X}"
+        raise HardwareRevisionUnsupportedError(
+            f"This chip routes VPP to socket pin 21, which needs the 3-position "
+            f"JP4 header introduced on RURP shield Rev 2.2. The programmer "
+            f"reported {reported}. Refusing to program — an earlier shield "
+            f"cannot route VPP there and attempting it can damage the EPROM.\n"
+            f"If this board really is a Rev 2.2 or 2.3, ADC detection cannot "
+            f"tell it apart from a Rev 2.0, so you must assert it once with "
+            f"'firestarter config --rev 4' (4 = Rev 2.2, 5 = Rev 2.3). Note "
+            f"that --rev takes the revision BYTE, not the silkscreen number: "
+            f"'--rev 2.2' truncates to 2 and selects the Rev 2.0 bucket.",
+            detected=detected,
+        )
+
     @staticmethod
     def _probe_port(
         port_name: str,
@@ -667,86 +768,75 @@ class SerialCommunicator:
                 communicator._fault_inject_outgoing = fault_inject_outgoing
             communicator.consume_remaining_input()
 
-            # FW-version handshake (independent of the user's command). Firmware
-            # emits the LFW-05 "OK: FW: <version>" text line on CMD_FW_VERSION;
-            # we use it to gate version compatibility before sending the actual
-            # user command. Prior firmware shipped MSG_OK_FW_HANDSHAKE with the
-            # version in every ack body, but that was dropped in Phase 9 — a
-            # dedicated probe is now the load-bearing version check.
-            exempt_cmds = [COMMAND_FW_VERSION]
-            command_code = command_to_send.get("state") or command_to_send.get("cmd")
-            if command_code not in exempt_cmds:
-                communicator.send_json_command({"state": COMMAND_FW_VERSION})
-                # CMD_FW_VERSION emits 2 acks: setup-complete "Ready" from
-                # init_programmer, then "OK: FW: <version>" from fw_get_version.
-                # Discard the first; parse the second for version validation.
-                pre_is_ok, _pre_msg = communicator.expect_ack()
-                if not pre_is_ok:
-                    logger.debug(
-                        f"Port {port_name}: FW-probe setup-ack not OK: {_pre_msg}"
-                    )
-                    communicator.disconnect()
-                    return None
-                fw_is_ok, fw_msg = communicator.expect_ack()
-                if not fw_is_ok:
-                    logger.debug(f"Port {port_name}: FW-probe payload not OK: {fw_msg}")
-                    communicator.disconnect()
-                    return None
-
-                try:
-                    if fw_msg and "FW:" in fw_msg:
-                        match = re.search(r"FW:\s*([\d.x]+)", fw_msg)
-                        if match:
-                            current_version = match.group(1).strip()
-
-                            # Phase 6 (LFW-05 + LHOST-04): refuse pre-v1.2 firmware. The firmware bumped  # noqa: E501
-                            # to major=3 in Phase 9. Set FIRESTARTER_DEV_ALLOW_PRE_V12=1 to bypass when  # noqa: E501
-                            # bench-testing a current host against a historical (v2.x) firmware build.  # noqa: E501
-                            allow_pre_v12 = (
-                                os.environ.get("FIRESTARTER_DEV_ALLOW_PRE_V12") == "1"
-                            )
-                            SerialCommunicator._validate_firmware_version(
-                                current_version, allow_pre_v12=allow_pre_v12
-                            )
-                            # CAP-01 (Phase 55): buffer-size advertisement moved from the
-                            # FW identity string to the MSG_OK_READY operation-setup ack.
-                            # The identity string is now "<ver>:<board>" only.
-                            # firmware_max_chunk is populated by _decode_id_frame override.
-                        else:
-                            raise FirmwareOutdatedError(
-                                "Could not parse firmware version from programmer response. "  # noqa: E501
-                                "Please upgrade the firmware using 'firestarter fw --install'."  # noqa: E501
-                            )
-                    else:
-                        raise FirmwareOutdatedError(
-                            "Firmware is outdated (pre-2.0.0). "
-                            "Please upgrade the firmware using 'firestarter fw --install'."  # noqa: E501
-                        )
-                except (IndexError, AttributeError):
-                    raise FirmwareOutdatedError(
-                        "Could not determine firmware version. "
-                        "Please upgrade the firmware using 'firestarter fw --install'."
-                    )
-
-                # FW probe succeeded; drain any trailing diagnostic frames the
-                # firmware emitted alongside the FW handshake before we send
-                # the user's actual command.
-                communicator.consume_remaining_input()
-
-            # Send the user's actual command (or CMD_FW_VERSION re-send when exempt).
+            # CAP-02: send the user's actual command straight away. The
+            # dedicated CMD_FW_VERSION pre-probe this replaces cost a full
+            # command exchange (2 acks) on every single connect; MSG_OK_READY
+            # now carries the firmware identity AND the effective hardware
+            # revision, so both gates run off the ack this command was going to
+            # produce anyway.
+            #
+            # Validating after the command is on the wire is safe by
+            # construction, not by luck. init_programmer_framed does run
+            # configure_memory before emitting MSG_OK_READY, but every
+            # configure_* handler is pure — it assigns function pointers and
+            # pulse defaults, nothing else. The VPP regulator is not engaged
+            # until firestarter_operation_init, which blocks on
+            # op_wait_for_ack(). Raising below means that ack is never sent, so
+            # the operation never starts and the rail stays down.
             communicator.send_json_command(command_to_send)
             is_ok, msg = communicator.expect_ack()
 
-            if is_ok:
-                communicator.programmer_info = msg
-                logger.debug(f"Programmer found on {port_name}: {msg}")
-                config_manager.set_value("port", port_name)  # Save successful port
-                return communicator
-            else:
+            if not is_ok:
                 logger.debug(f"Port {port_name} responded but not with OK: {msg}")
                 communicator.disconnect()
                 return None
 
+            # Version gate. The POLICY is untouched (D-01/D-03) — only its
+            # source moved, from the retired probe's "OK: FW: <ver>" text line
+            # to the identity field of the ack. Same [\d.x]+ extraction as the
+            # old regex performed, so _validate_firmware_version still receives
+            # "3.0.0" rather than the full "3.0.0:uno" identity (feeding it the
+            # board suffix would make int() choke and reject every board).
+            identity = communicator.firmware_identity
+            version_match = re.match(r"[\d.x]+", identity) if identity else None
+            if version_match is None:
+                raise FirmwareOutdatedError(
+                    "Programmer did not report a firmware version in its "
+                    "operation-setup ack. This host requires firmware that "
+                    "carries the version and hardware revision in that ack. "
+                    "Please upgrade the firmware using 'firestarter fw --install'."  # noqa: E501
+                )
+            # Phase 6 (LFW-05 + LHOST-04): refuse pre-v1.2 firmware. The firmware bumped  # noqa: E501
+            # to major=3 in Phase 9. Set FIRESTARTER_DEV_ALLOW_PRE_V12=1 to bypass when  # noqa: E501
+            # bench-testing a current host against a historical (v2.x) firmware build.  # noqa: E501
+            SerialCommunicator._validate_firmware_version(
+                version_match.group(0),
+                allow_pre_v12=os.environ.get("FIRESTARTER_DEV_ALLOW_PRE_V12") == "1",
+            )
+
+            # Shield-revision gate — ordered after the version check because
+            # firmware old enough to fail that check cannot be trusted to have
+            # reported a revision at all, and before the caller is handed a
+            # connection it would immediately start driving.
+            SerialCommunicator._validate_hardware_revision(
+                command_to_send, communicator.hw_revision
+            )
+
+            communicator.programmer_info = msg
+            logger.debug(f"Programmer found on {port_name}: {msg}")
+            config_manager.set_value("port", port_name)  # Save successful port
+            return communicator
+
+        except HardwareRevisionUnsupportedError:
+            # MUST precede the SerialError clause below (it is a subclass) and
+            # MUST re-raise. Falling through to `return None` would surface a
+            # deliberate safety refusal as "no programmer found" — the worst
+            # possible message for an operator looking at a board that is
+            # plainly attached, and one that invites them to go hunting for a
+            # cable fault instead of reading the actual reason.
+            if communicator:
+                communicator.disconnect()
+            raise
         except (SerialError, FirmwareOutdatedError) as e:
             logger.debug(f"Probe failed for {port_name}: {e}")
             if communicator:
@@ -811,11 +901,20 @@ class SerialCommunicator:
                         logger.info("Connecting... OK      ", extra={"status": "end"})
                     # The "Programmer found on..." message is logged by _probe_port on a new line.  # noqa: E501
                     return communicator
-            except (FirmwareOutdatedError, ProtocolNotImplementedError) as e:
+            except (
+                FirmwareOutdatedError,
+                HardwareRevisionUnsupportedError,
+                ProtocolNotImplementedError,
+            ) as e:
                 if status_update_active:
                     logger.info("Connecting... Failed  ", extra={"status": "end"})
-                # If firmware is outdated or protocol not implemented, stop probing  # noqa: E501
-                # and raise the specific error (both are stop-probing, surface-the-specific-error cases).  # noqa: E501
+                # If firmware is outdated, the shield revision cannot safely
+                # drive this chip, or the protocol is not implemented, stop
+                # probing and raise the specific error (all three are
+                # stop-probing, surface-the-specific-error cases). Listing the
+                # revision error here is about closing the "Connecting..."
+                # status line — it already escapes the loop by not matching any
+                # clause, but it would leave that line dangling on the way out.
                 raise e
 
         # If the loop completes without finding a programmer, it's a failure.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,6 +219,11 @@ def make_comm(fake_serial):
         instance.firmware_buffer_size = None
         # Phase-54 (EVEN-01): firmware-advertised MAIN-path decode capacity (None until probed)
         instance.firmware_max_chunk = None
+        # CAP-02: firmware identity + effective HW revision, both carried in the
+        # MSG_OK_READY ack. None until probed — and None is a REJECT for the
+        # shield-revision gate, so a fixture that forgets these fails closed.
+        instance.firmware_identity = None
+        instance.hw_revision = None
         # Phase-120 (D-15 / HOST-06): bounded per-connection observed-id record
         instance.seen_message_ids = set()
         return instance

--- a/tests/test_chip_test_sdp_leg.py
+++ b/tests/test_chip_test_sdp_leg.py
@@ -198,6 +198,7 @@ from firestarter.exceptions import (
     EpromOperationError,
     FirmwareOutdatedError,
     HardwareOperationError,
+    HardwareRevisionUnsupportedError,
     ProgrammerNotFoundError,
     SerialError,
     SerialTimeoutError,
@@ -610,31 +611,40 @@ def test_hardware_error_degrades_one_step():
     operator.check_eprom_blank.assert_called()
 
 
-@pytest.mark.parametrize("exc_cls", [ProgrammerNotFoundError, FirmwareOutdatedError])
+@pytest.mark.parametrize(
+    "exc_cls",
+    [ProgrammerNotFoundError, FirmwareOutdatedError, HardwareRevisionUnsupportedError],
+)
 def test_run_fatal_escapes(exc_cls):
-    """ProgrammerNotFoundError and FirmwareOutdatedError still ESCAPE
-    run_plan unchanged (D-08) -- these are run-fatal host-setup conditions
-    that belong to cli_handlers.py's @map_typed_errors mapper, not chip
-    findings. Escape is asserted by object IDENTITY, not just class, so a
-    re-wrap cannot pass.
+    """ProgrammerNotFoundError, FirmwareOutdatedError and
+    HardwareRevisionUnsupportedError still ESCAPE run_plan unchanged (D-08) --
+    these are run-fatal host-setup conditions that belong to cli_handlers.py's
+    @map_typed_errors mapper, not chip findings. Escape is asserted by object
+    IDENTITY, not just class, so a re-wrap cannot pass.
 
     Standing invariant: SerialError.__subclasses__() is pinned to the
-    measured three-class census. A fourth subclass added by a later phase
-    without updating _run_step's re-raise clause would silently bypass it
-    and become a false-green no-board report -- this assertion is what
-    would catch that."""
+    measured census. A subclass added by a later phase without updating
+    _run_step's re-raise clause would silently bypass it and become a
+    false-green no-board report -- this assertion is what would catch that.
+
+    CAP-02 grew the census from three to four. The gate fired exactly as
+    designed when HardwareRevisionUnsupportedError was introduced: without the
+    matching _run_step change, a shield-revision refusal would have degraded to
+    a BAD step per remaining operation, reporting a damaged-looking chip when
+    the real cause was a shield that cannot safely drive it."""
     assert set(SerialError.__subclasses__()) == {
         SerialTimeoutError,
         ProgrammerNotFoundError,
         FirmwareOutdatedError,
+        HardwareRevisionUnsupportedError,
     }, (
         "SerialError gained or lost a subclass since D-08 was measured -- "
-        "_run_step's (ProgrammerNotFoundError, FirmwareOutdatedError) "
-        "re-raise clause is only complete against the THREE-class census "
-        "D-08 names; a new subclass here would silently fall through to "
-        "the (SerialError, HardwareOperationError) degrade clause instead "
-        "of escaping, turning a no-board/old-firmware run into a false "
-        "BAD-step report (133-CONTEXT.md D-08)."
+        "_run_step's (ProgrammerNotFoundError, FirmwareOutdatedError, "
+        "HardwareRevisionUnsupportedError) re-raise clause is only complete "
+        "against the FOUR-class census named here; a new subclass would "
+        "silently fall through to the (SerialError, HardwareOperationError) "
+        "degrade clause instead of escaping, turning a no-board/old-firmware/"
+        "wrong-shield run into a false BAD-step report (133-CONTEXT.md D-08)."
     )
 
     operator = _mock_operator()

--- a/tests/test_fwguard.py
+++ b/tests/test_fwguard.py
@@ -16,17 +16,56 @@ Covers four paths through SerialCommunicator._probe_port's pre-v1.2 guard:
   4. Malformed version string -> major defaults to 0 -> refuse fires
      (T-06-17 mitigation).
 
+CAP-02 UPDATE: the version no longer arrives as the "FW: <ver>" text line of a
+dedicated CMD_FW_VERSION probe — that probe is retired. It now rides in the
+MSG_OK_READY ack and is decoded into `SerialCommunicator.firmware_identity`.
+These tests therefore patch that attribute (class-level, so patch.object works)
+instead of stuffing a version into expect_ack's message string. The GUARD
+POLICY under test is unchanged: _validate_firmware_version still receives the
+same "<major>.<minor>.<patch>" shape, because _probe_port strips the ":<board>"
+suffix with the same [\\d.x]+ extraction the old regex performed.
+
 The tests short-circuit the real serial connection via unittest.mock.patch.object
 per PATTERNS §"firestarter_app/tests/test_fwguard.py". An autouse class fixture
 guarantees the escape-hatch env var is UNSET for every test that expects the
 strict path, so the suite is hermetic against the developer's shell environment.
 """
 
+import contextlib
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from firestarter.serial_comm import FirmwareOutdatedError, SerialCommunicator
+
+
+@contextlib.contextmanager
+def _probe_with_identity(identity):
+    """Patch out serial I/O and pin the CAP-02 firmware identity string.
+
+    `identity` mirrors the real wire value: "<version>:<board>", e.g.
+    "3.0.0:uno". Passing the board suffix is deliberate — it keeps these tests
+    honest about _probe_port having to strip it before the version policy runs.
+    """
+    with (
+        patch.object(SerialCommunicator, "expect_ack", return_value=(True, "Ready")),
+        patch.object(SerialCommunicator, "send_json_command", return_value=42),
+        patch.object(SerialCommunicator, "consume_remaining_input", return_value=None),
+        patch.object(SerialCommunicator, "disconnect", return_value=None),
+        patch.object(SerialCommunicator, "firmware_identity", identity),
+        patch.object(SerialCommunicator, "__init__", lambda self, port, **k: None),
+    ):
+        yield
+
+
+def _probe():
+    """Run _probe_port with a plain non-gated command (no bus-config)."""
+    return SerialCommunicator._probe_port(
+        port_name="/dev/null",
+        baud_rate=250000,
+        command_to_send={"state": 1},
+        config_manager=MagicMock(),
+    )
 
 
 class TestFirmwareVersionGuard:
@@ -44,25 +83,9 @@ class TestFirmwareVersionGuard:
 
     def test_refuse_pre_v3_firmware(self):
         """LFW-05 / LHOST-04 path: refuse. v2.0.11 firmware must trip the guard."""
-        mock_msg = "FW: 2.0.11, HW: Rev2, Cmd: 0x0d"
-        with (
-            patch.object(
-                SerialCommunicator, "expect_ack", return_value=(True, mock_msg)
-            ),
-            patch.object(SerialCommunicator, "send_json_command", return_value=42),
-            patch.object(
-                SerialCommunicator, "consume_remaining_input", return_value=None
-            ),
-            patch.object(SerialCommunicator, "disconnect", return_value=None),
-            patch.object(SerialCommunicator, "__init__", lambda self, port, **k: None),
-        ):
+        with _probe_with_identity("2.0.11:uno"):
             with pytest.raises(FirmwareOutdatedError, match="pre-v1.2") as exc_info:
-                SerialCommunicator._probe_port(
-                    port_name="/dev/null",
-                    baud_rate=250000,
-                    command_to_send={"state": 1},
-                    config_manager=MagicMock(),
-                )
+                _probe()
             # Locked-wording assertions: the exception must name the version it
             # saw and the concrete remedy command.
             assert "2.0.11" in str(exc_info.value)
@@ -71,50 +94,18 @@ class TestFirmwareVersionGuard:
 
     def test_accept_v3_firmware(self):
         """LFW-05 / LHOST-04 path: accept. v3.0.0 firmware passes the guard."""
-        mock_msg = "FW: 3.0.0, HW: Rev2, Cmd: 0x0d"
-        with (
-            patch.object(
-                SerialCommunicator, "expect_ack", return_value=(True, mock_msg)
-            ),
-            patch.object(SerialCommunicator, "send_json_command", return_value=42),
-            patch.object(
-                SerialCommunicator, "consume_remaining_input", return_value=None
-            ),
-            patch.object(SerialCommunicator, "disconnect", return_value=None),
-            patch.object(SerialCommunicator, "__init__", lambda self, port, **k: None),
-        ):
+        with _probe_with_identity("3.0.0:uno"):
             try:
-                SerialCommunicator._probe_port(
-                    port_name="/dev/null",
-                    baud_rate=250000,
-                    command_to_send={"state": 1},
-                    config_manager=MagicMock(),
-                )
+                _probe()
             except FirmwareOutdatedError as exc:
                 pytest.fail(f"v3.0.0 firmware should NOT trip the guard; got: {exc}")
 
     def test_dev_escape_hatch_env_var(self, monkeypatch):
         """LFW-05 / LHOST-04 path: escape-hatch. FIRESTARTER_DEV_ALLOW_PRE_V12=1 bypasses."""  # noqa: E501
         monkeypatch.setenv("FIRESTARTER_DEV_ALLOW_PRE_V12", "1")
-        mock_msg = "FW: 2.0.11, HW: Rev2, Cmd: 0x0d"
-        with (
-            patch.object(
-                SerialCommunicator, "expect_ack", return_value=(True, mock_msg)
-            ),
-            patch.object(SerialCommunicator, "send_json_command", return_value=42),
-            patch.object(
-                SerialCommunicator, "consume_remaining_input", return_value=None
-            ),
-            patch.object(SerialCommunicator, "disconnect", return_value=None),
-            patch.object(SerialCommunicator, "__init__", lambda self, port, **k: None),
-        ):
+        with _probe_with_identity("2.0.11:uno"):
             try:
-                SerialCommunicator._probe_port(
-                    port_name="/dev/null",
-                    baud_rate=250000,
-                    command_to_send={"state": 1},
-                    config_manager=MagicMock(),
-                )
+                _probe()
             except FirmwareOutdatedError as exc:
                 pytest.fail(
                     f"Escape hatch should bypass the major-version refuse; got: {exc}"
@@ -122,27 +113,21 @@ class TestFirmwareVersionGuard:
 
     def test_malformed_version_defaults_to_refuse(self):
         """LFW-05 / LHOST-04 path: malformed. Garbage version -> major=0 -> refuse (T-06-17)."""  # noqa: E501
-        # Force the parser to reach a path where int(...split('.')[0]) raises:
-        # `NOT_A_VERSION` matches the FW: regex's `[\d.x]+` zero-or-more pattern?
-        # No — `[\d.x]+` would not capture `NOT_A_VERSION`. Use a string that
-        # matches the regex but cannot parse as int: `x.x.x` (the version-regex
-        # accepts 'x' literally; `int('x')` raises ValueError).
-        mock_msg = "FW: x.x.x, HW: Rev2, Cmd: 0x0d"
-        with (
-            patch.object(
-                SerialCommunicator, "expect_ack", return_value=(True, mock_msg)
-            ),
-            patch.object(SerialCommunicator, "send_json_command", return_value=42),
-            patch.object(
-                SerialCommunicator, "consume_remaining_input", return_value=None
-            ),
-            patch.object(SerialCommunicator, "disconnect", return_value=None),
-            patch.object(SerialCommunicator, "__init__", lambda self, port, **k: None),
-        ):
+        # `x.x.x` matches the version-extraction pattern `[\d.x]+` (which accepts
+        # 'x' literally) but cannot parse as int, so _validate_firmware_version
+        # falls to major=0 and the pre-v1.2 refuse fires.
+        with _probe_with_identity("x.x.x:uno"):
             with pytest.raises(FirmwareOutdatedError, match="pre-v1.2"):
-                SerialCommunicator._probe_port(
-                    port_name="/dev/null",
-                    baud_rate=250000,
-                    command_to_send={"state": 1},
-                    config_manager=MagicMock(),
-                )
+                _probe()
+
+    def test_absent_identity_refuses(self):
+        """CAP-02: firmware that sends no identity in the ack must be refused.
+
+        Pre-CAP-02 firmware emits the 2-byte MSG_OK_READY, leaving
+        firmware_identity None. That is the case the retired CMD_FW_VERSION
+        probe used to cover, so it needs an explicit refuse test now: the host
+        must NOT treat "no version reported" as "version fine".
+        """
+        with _probe_with_identity(None):
+            with pytest.raises(FirmwareOutdatedError, match="did not report"):
+                _probe()

--- a/tests/test_hw_revision_gate.py
+++ b/tests/test_hw_revision_gate.py
@@ -1,0 +1,285 @@
+"""
+Project Name: Firestarter
+Copyright (c) 2024 Henrik Olsson
+
+Permission is hereby granted under MIT license.
+
+CAP-02 — shield-revision safety gate + extended MSG_OK_READY decode.
+
+Chips whose bus-config routes VPP to bus line 11 (socket pin 21 on the
+DIP24_2716 / DIP24_2532 pinouts) need the 3-position JP4 header introduced on
+RURP shield Rev 2.2. Driving them on an earlier shield is a chip-damage path,
+so the host refuses at connect time.
+
+Three things are proved here:
+
+  1. `_validate_hardware_revision` -- the pure policy. Most importantly that it
+     is an ALLOWLIST and not a `>=` comparison: REVISION_UNKNOWN is 0xFE, which
+     is numerically ABOVE REVISION_2_2 (0x04), so a comparison would admit
+     precisely the boards whose revision could not be determined.
+  2. `_decode_id_frame` -- that the extended ack is parsed, that the legacy
+     2-byte ack still yields its buffer size, and that a malformed length
+     prefix degrades to "no identity" (reject) rather than a partial string.
+  3. The gate's coupling to the REAL database -- that DIP24_2716 / DIP24_2532
+     genuinely emit `vpp-pin: 11` and that no other pinout does. Without this,
+     a pinout edit could silently move chips in or out of the gate's scope.
+"""
+
+import struct
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from firestarter.constants import (
+    REVISION_0,
+    REVISION_1,
+    REVISION_2_0,
+    REVISION_2_1,
+    REVISION_2_2,
+    REVISION_2_3,
+    REVISION_UNKNOWN,
+)
+from firestarter.database import EpromDatabase
+from firestarter.exceptions import HardwareRevisionUnsupportedError
+from firestarter.messages import MSG_OK_READY
+from firestarter.serial_comm import SerialCommunicator
+
+GATED_VPP_LINE = 11
+
+# A wire dict for a chip that needs Rev 2.2+ (VPP on bus line 11), and one for
+# an ordinary chip that does not.
+GATED_CMD = {"cmd": 1, "bus-config": {"bus": [0, 1, 2], "vpp-pin": GATED_VPP_LINE}}
+UNGATED_CMD = {"cmd": 1, "bus-config": {"bus": [0, 1, 2], "vpp-pin": 15}}
+
+
+def _validate(command, detected):
+    return SerialCommunicator._validate_hardware_revision(command, detected)
+
+
+# ---------------------------------------------------------------------------
+# 1. Pure policy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("allowed", [REVISION_2_2, REVISION_2_3])
+def test_gated_chip_passes_on_rev_2_2_and_later(allowed):
+    """Rev 2.2 and Rev 2.3 both carry the 3-position header, so both pass."""
+    _validate(GATED_CMD, allowed)  # must not raise
+
+
+@pytest.mark.parametrize(
+    "refused",
+    [REVISION_0, REVISION_1, REVISION_2_0, REVISION_2_1],
+)
+def test_gated_chip_refused_on_earlier_shields(refused):
+    """Every pre-2.2 revision is refused, including the REVISION_2_0 bucket.
+
+    REVISION_2_0 is the broad ADC bucket covering Rev 2.0/2.1/2.2, so a genuine
+    Rev 2.2 lands here until the operator writes the EEPROM override. Refusing
+    is the intended outcome: the operator must look at the physical header and
+    assert it, and that assertion IS the safety mechanism.
+    """
+    with pytest.raises(HardwareRevisionUnsupportedError):
+        _validate(GATED_CMD, refused)
+
+
+def test_revision_unknown_is_refused_despite_being_numerically_higher():
+    """THE trap this gate exists to avoid.
+
+    REVISION_UNKNOWN (0xFE) is numerically greater than REVISION_2_2 (0x04), so
+    the obvious `detected >= REVISION_2_2` spelling would ADMIT a board whose
+    revision could not be determined -- the single case most deserving a
+    refusal. The first assertion pins that arithmetic so this test keeps
+    explaining itself if the enum values ever move.
+    """
+    assert REVISION_UNKNOWN > REVISION_2_2, (
+        "the REVISION_* bytes are not a version-ordered scale; if this ever "
+        "becomes false the allowlist is still correct but this test's "
+        "rationale needs rewriting"
+    )
+    with pytest.raises(HardwareRevisionUnsupportedError):
+        _validate(GATED_CMD, REVISION_UNKNOWN)
+
+
+def test_override_absent_sentinel_is_refused():
+    """0xFF ("no EEPROM override active") is not a revision and must refuse."""
+    with pytest.raises(HardwareRevisionUnsupportedError):
+        _validate(GATED_CMD, 0xFF)
+
+
+def test_absent_revision_is_refused():
+    """Firmware predating CAP-02 sends no revision byte -> detected is None.
+
+    None must be a REJECT, never a pass: "the firmware didn't tell me" is not
+    evidence that the shield is safe.
+    """
+    with pytest.raises(HardwareRevisionUnsupportedError) as exc_info:
+        _validate(GATED_CMD, None)
+    assert exc_info.value.detected is None
+    assert "firmware predates" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        UNGATED_CMD,
+        {"cmd": 1, "bus-config": {"bus": [0, 1]}},  # no vpp-pin at all
+        {"cmd": 1},  # no bus-config at all
+        {"state": 13},  # a bare state command
+    ],
+)
+def test_ungated_chips_pass_on_any_revision(command):
+    """Only VPP-on-line-11 chips are gated; everything else is untouched.
+
+    Checked against the WORST revision value so a gate that accidentally
+    widened to all chips would fail here rather than silently bricking every
+    operation on a Rev 2.0 board.
+    """
+    _validate(command, REVISION_2_0)  # must not raise
+    _validate(command, None)  # must not raise
+
+
+def test_refusal_message_gives_the_exact_remedy():
+    """The error must name the byte to write, not the silkscreen number.
+
+    `firestarter config --rev` casts through int(), so '--rev 2.2' truncates to
+    2 and silently selects the Rev 2.0 bucket -- the exact opposite of what an
+    operator typing it intends. The message has to pre-empt that.
+    """
+    with pytest.raises(HardwareRevisionUnsupportedError) as exc_info:
+        _validate(GATED_CMD, REVISION_2_0)
+    text = str(exc_info.value)
+    assert "firestarter config --rev 4" in text
+    assert "--rev 2.2" in text and "truncates" in text
+    assert exc_info.value.detected == REVISION_2_0
+
+
+# ---------------------------------------------------------------------------
+# 2. Extended MSG_OK_READY decode
+# ---------------------------------------------------------------------------
+
+
+def _ready_body(params: bytes) -> bytes:
+    """Build the `body` _decode_id_frame receives: [id][params][crc]."""
+    from tests.conftest import _ref_crc8_ccitt
+
+    payload = bytes([MSG_OK_READY]) + params
+    return payload + bytes([_ref_crc8_ccitt(payload)])
+
+
+def _cap02_params(buffer_size: int, revision: int, identity: str) -> bytes:
+    raw = identity.encode("ascii")
+    return struct.pack(">H", buffer_size) + bytes([revision, len(raw)]) + raw
+
+
+def test_decode_extended_ack_populates_all_three_fields(make_comm):
+    comm = make_comm()
+    body = _ready_body(_cap02_params(1024, REVISION_2_2, "3.0.0:leonardo"))
+    comm._decode_id_frame(len(body), body)
+
+    assert comm.firmware_max_chunk == 1024
+    assert comm.hw_revision == REVISION_2_2
+    assert comm.firmware_identity == "3.0.0:leonardo"
+
+
+def test_decode_legacy_two_byte_ack_still_yields_buffer_size(make_comm):
+    """Pre-CAP-02 firmware: buffer size decodes, the CAP-02 fields stay None."""
+    comm = make_comm()
+    body = _ready_body(struct.pack(">H", 512))
+    comm._decode_id_frame(len(body), body)
+
+    assert comm.firmware_max_chunk == 512
+    assert comm.hw_revision is None
+    assert comm.firmware_identity is None
+
+
+def test_decode_truncated_version_prefix_leaves_identity_none(make_comm):
+    """A length prefix claiming more bytes than are present must not yield a
+    partial string -- the host would then gate on a mangled version. Identity
+    stays None, which is a refuse."""
+    comm = make_comm()
+    # Claims 40 version bytes but supplies 3.
+    body = _ready_body(struct.pack(">H", 512) + bytes([REVISION_2_2, 40]) + b"3.0")
+    comm._decode_id_frame(len(body), body)
+
+    assert comm.firmware_identity is None
+    # The revision byte precedes the malformed prefix and is still trustworthy.
+    assert comm.hw_revision == REVISION_2_2
+
+
+def test_decode_implausible_buffer_size_is_clamped_away(make_comm):
+    """The CAP-01 [1, 4096] plausibility clamp survives the widened length
+    test -- an absurd advertised size must leave firmware_max_chunk unset so
+    the 512 floor applies (T-55-06)."""
+    comm = make_comm()
+    body = _ready_body(_cap02_params(60000, REVISION_2_2, "3.0.0:uno"))
+    comm._decode_id_frame(len(body), body)
+
+    assert comm.firmware_max_chunk is None
+    assert comm.hw_revision == REVISION_2_2
+
+
+# ---------------------------------------------------------------------------
+# 3. Coupling to the real database
+# ---------------------------------------------------------------------------
+
+
+def test_exactly_two_pinouts_emit_the_gated_vpp_line():
+    """Pins the gate to real data.
+
+    If a pinout edit moves another layout onto bus line 11, or moves the 24-pin
+    UV-EPROM layouts off it, this fails -- which is the point. The gate keys on
+    a wire value, so its scope is defined by pinouts.json, not by this module.
+    """
+    db = EpromDatabase(skip_local_override=True)
+    gated = set()
+    for key in db.pin_maps:
+        pin_count = int(key.split("_")[0].removeprefix("DIP"))
+        bus_config = db.get_bus_config(pin_count, key)
+        if bus_config and bus_config.get("vpp-pin") == GATED_VPP_LINE:
+            gated.add(key)
+
+    assert gated == {"DIP24_2716", "DIP24_2532"}
+
+
+# ---------------------------------------------------------------------------
+# 4. Integration through _probe_port
+# ---------------------------------------------------------------------------
+
+
+def _probe(command, revision):
+    with (
+        patch.object(SerialCommunicator, "expect_ack", return_value=(True, "Ready")),
+        patch.object(SerialCommunicator, "send_json_command", return_value=42),
+        patch.object(SerialCommunicator, "consume_remaining_input", return_value=None),
+        patch.object(SerialCommunicator, "disconnect", return_value=None),
+        patch.object(SerialCommunicator, "firmware_identity", "3.0.0:uno"),
+        patch.object(SerialCommunicator, "hw_revision", revision),
+        patch.object(SerialCommunicator, "__init__", lambda self, port, **k: None),
+    ):
+        return SerialCommunicator._probe_port(
+            port_name="/dev/null",
+            baud_rate=250000,
+            command_to_send=command,
+            config_manager=MagicMock(),
+        )
+
+
+def test_probe_port_refuses_gated_chip_on_rev_2_0_class_board():
+    """The refusal must ESCAPE _probe_port as its own typed error.
+
+    _probe_port's default failure mode is `return None`, which find_and_connect
+    turns into "No compatible programmer found on any port" -- a message that
+    sends an operator hunting for a cable fault when the board is plainly
+    attached and the real answer is "wrong shield for this chip".
+    """
+    with pytest.raises(HardwareRevisionUnsupportedError):
+        _probe(GATED_CMD, REVISION_2_0)
+
+
+def test_probe_port_allows_gated_chip_on_asserted_rev_2_2():
+    assert _probe(GATED_CMD, REVISION_2_2) is not None
+
+
+def test_probe_port_allows_ungated_chip_on_rev_2_0_class_board():
+    assert _probe(UNGATED_CMD, REVISION_2_0) is not None

--- a/tests/test_protocol_not_implemented_production_path.py
+++ b/tests/test_protocol_not_implemented_production_path.py
@@ -102,15 +102,19 @@ def _make_fake_comm(fake_ser: _FakeSerial) -> SerialCommunicator:
 
 
 def _feed_fw_handshake_then_0xbb(fake_ser: _FakeSerial) -> None:
-    """Pre-load the fake serial with the FW-version handshake acks followed by a 0xBB ERROR.
+    """Pre-load the fake serial with a 0xBB ERROR as the first response.
 
-    The probe sequence in _probe_port:
-      1. setup-complete ack: "OK: Ready"   (init_programmer OK ack)
-      2. FW version ack:    "OK: FW: 3.0.0, ..."
-      3. user-command ack:   0xBB ERROR id-frame  <- triggers ProtocolNotImplementedError
+    The probe sequence in _probe_port (CAP-02):
+      1. user-command ack: 0xBB ERROR id-frame  <- triggers ProtocolNotImplementedError
+
+    Before CAP-02 this helper also fed the two acks of a dedicated
+    CMD_FW_VERSION pre-probe ("OK: Ready" then "OK: FW: 3.0.0, ..."), because
+    _probe_port sent that probe ahead of the user's command. That probe is
+    retired — the firmware identity now rides in the MSG_OK_READY ack — so the
+    user's command is the FIRST thing on the wire and its ack is the first
+    response. Feeding the old handshake here would make expect_ack consume
+    "OK: Ready" as the user-command ack and never reach the 0xBB frame.
     """
-    fake_ser.feed(b"OK: Ready\n")
-    fake_ser.feed(f"OK: {FW_VERSION_MSG}\n".encode())
     fake_ser.feed(
         build_frame(MSG_ERR_PROTOCOL_NOT_IMPLEMENTED, bytes([PROTOCOL_VALUE]))
     )
@@ -267,11 +271,10 @@ def test_e_non_0xbb_error_at_probe_time_surfaces_as_generic_path() -> None:
     """
     from firestarter.exceptions import ProgrammerNotFoundError
 
-    # Feed: version handshake OK, then a generic (non-0xBB) ERROR
-    fake_ser = _FakeSerial()
-    fake_ser.feed(b"OK: Ready\n")
-    fake_ser.feed(f"OK: {FW_VERSION_MSG}\n".encode())
+    # CAP-02: the user's command is the first thing on the wire (the dedicated
+    # CMD_FW_VERSION pre-probe is retired), so its ack is the first response.
     # MSG_ERR_NOT_SUPPORTED (0xa5) — generic error, NOT 0xBB
+    fake_ser = _FakeSerial()
     fake_ser.feed(build_frame(MSG_ERR_NOT_SUPPORTED, bytes([0x00])))
 
     def mock_init(self, port=None, baud_rate=None, **kwargs):


### PR DESCRIPTION
Host half of the CAP-02 pair. **Must land together with** henols/firestarter#49 — this host refuses firmware that predates that change.

## The safety change

Chips whose bus-config routes VPP to bus line 11 (socket pin 21 on the `DIP24_2716` / `DIP24_2532` pinouts) need the 3-position JP4 header introduced on RURP shield Rev 2.2. Driving them on an earlier shield is a chip-damage path. The host now refuses at connect time, **before the firmware engages the VPP regulator**.

## Retires the CMD_FW_VERSION pre-probe

`_probe_port` used to send a dedicated `CMD_FW_VERSION` command and consume two acks purely to read the version, *then* send the user's command. Firmware now carries the version and the effective hardware revision in the `MSG_OK_READY` ack of whatever command it is answering, so the user's command goes first and both gates run off its ack. One fewer command exchange per connect.

Sending the real command before validating is safe **by construction, not by luck**: `init_programmer_framed` does run `configure_memory` before emitting `MSG_OK_READY`, but every `configure_*` handler is pure — function-pointer assignment and pulse defaults only. The VPP regulator is not engaged until `firestarter_operation_init`, which blocks on `op_wait_for_ack()`. Raising here means that ack is never sent, so the operation never starts and the rail stays down.

## The gate is an allowlist, not a comparison

The `REVISION_*` bytes are **not** a version-ordered scale:

```
REVISION_2_2     = 0x04
REVISION_UNKNOWN = 0xFE   # numerically ABOVE 2.2
```

`detected >= REVISION_2_2` would admit precisely the boards whose revision could not be determined. Membership in `{REVISION_2_2, REVISION_2_3}` fails closed for `0xFE`, for the `0xFF` override-absent sentinel, for the `REVISION_2_0` broad bucket, and for `None` (pre-CAP-02 firmware).

A `>=` was planted and confirmed to turn exactly the two trap tests red before the allowlist went back in — the tests are not vacuously green.

## The override requirement is the safety mechanism

ADC detection collapses Rev 2.0/2.1/2.2 into `REVISION_2_0`, so a genuine Rev 2.2 is refused until the operator writes the EEPROM override. That is the design, not a gap: the operator has to look at the physical header and assert it.

The refusal message names the exact byte to write, because `config --rev` casts through `int()` and `--rev 2.2` silently truncates to `2` — selecting the Rev 2.0 bucket, the opposite of what the operator intends. **That truncation is a live trap in `config` and is not fixed here.**

## Collateral fixed, not papered over

The Phase-133 `SerialError` census gate fired on the new subclass and pointed at a genuine defect: `chip_test.py::_run_step`'s re-raise clause named only two subclasses, so a shield-revision refusal would have degraded to a BAD step per remaining operation — reporting a damaged-looking chip when the real cause was the wrong shield. `_run_step` now re-raises it; the census is updated to four with the reasoning recorded.

`firmware_identity` / `hw_revision` are declared at **class** level because several suites patch `__init__` to a no-op and `conftest`'s `make_comm` builds instances via `__new__`. Instance-only attributes would `AttributeError` into `_probe_port`'s broad `except Exception` and degrade to "no programmer found".

## Compatibility — breaking, by design

| | old firmware | new firmware |
|---|---|---|
| **old host** | works | 3+ byte params fail the `len == 2` test → falls to the 512 chunk floor. Correct, halves Leonardo throughput. |
| **new host** | 2-byte ack → no version, no revision → `FirmwareOutdatedError` | full function |

Lockstep host+firmware upgrade, consistent with PROJECT.md's stated constraint.

## Tests

**1532 pass** (baseline 1508). 22 new in `tests/test_hw_revision_gate.py` covering the policy, the extended/legacy/truncated ack decode, and the gate's coupling to the *real* pinout data — `test_exactly_two_pinouts_emit_the_gated_vpp_line` asserts `{DIP24_2716, DIP24_2532}` against the live database, so a pinout edit that moves chips in or out of the gate's scope fails loudly.

ruff lint + format clean. The mypy **watermark** gate could not be run locally — it exits 2 on numpy stubs under the devcontainer's py3.12 versus the pinned CI version, identically with these changes stashed. CI runs it on the pinned version; that result is the one that counts. Direct mypy over the 8 strict modules is clean apart from a pre-existing `submit.py:666` error.

## Reviewer attention, please

- **No bench validation.** This is a safety gate whose purpose is preventing chip damage, verified only by reading both sides plus unit tests mirroring the firmware's packing. It wants a real run before shipping.
- **Is the gate too broad?** It catches all 16 chips on those two pinouts, including 15 ordinary Intel 2716s. If only the TI 25xx parts genuinely need Rev 2.2+, this stops chips that work today on a Rev 2.0. If the capability really is keyed on the VPP routing rather than the part, it is exactly right. That question is open and decides whether this ships as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)