### PR TITLE
ci: run Host CI on every branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,19 @@
 # Phase 127 (D-01/D-02): adds a manual dispatch trigger and a second, isolated
 # ci-py32 job that installs the [py32] extra and runs the real-pyusb API
 # surface tests. No automatic trigger changed.
+# CI runs on EVERY branch. The push trigger used to be main-only, so a push to
+# a milestone or fix branch ran no gate at all -- ruff, the mypy watermark and
+# the coverage floor were only enforced once a PR existed or once work reached
+# main. Nothing in this workflow publishes: it produces no release, no tag and
+# no PyPI upload, so there is no publish boundary to guard here. Artefact
+# publishing lives in release.yml (main), beta-release.yml (beta) and
+# publish.yml (release:published), and none of those triggers is touched.
 name: Host CI
 on:
   push:
-    branches:
-    - main
+    # '**' matches every BRANCH but no tags. A bare `push:` would also fire on
+    # tag pushes; milestone-close tag pushes must keep firing zero CI.
+    branches: ['**']
     paths-ignore:
     - '**.md'
     - '.gitignore'
@@ -23,6 +31,15 @@ on:
     - '.vscode/**'
     - '.editorconfig'
   workflow_dispatch:
+
+# A same-repo PR branch now matches both `push` and `pull_request`, so
+# supersede stale runs per ref instead of queueing both to completion.
+# main/beta are excluded from cancellation: their runs are what the
+# publishing workflows are judged against, and a cancelled gate reads as a
+# failed gate.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/beta' }}
 
 jobs:
   ci:


### PR DESCRIPTION
The `push` trigger was `main`-only, so **a push to a milestone or fix branch ran no gate at all** — ruff, ruff format, the mypy watermark and the 70% coverage floor were enforced only once a PR existed or once work reached main.

## Publishing is untouched

Nothing in `ci.yml` publishes: no release, no tag, no PyPI upload. There is no publish boundary to add here, and none of the three workflows that *do* publish is modified:

| workflow | trigger | status |
|---|---|---|
| `release.yml` | `push: [main]` | untouched |
| `beta-release.yml` | `push: [beta]` | untouched |
| `publish.yml` | `release: [published]` | untouched — only fires from a release, which only the two above can create |

Companion to henols/firestarter#50, which does the same for the firmware repo. That one is the more delicate half: `build.yml` there has steps that auto-commit and publish a `make_latest` release, and they needed explicit `if:` guards once the trigger opened up. Nothing of that kind exists here.

## Two details worth a look

- **The trigger is `branches: ['**']`, not a bare `push:`.** A bare push trigger *also fires on tag pushes*, and this project pushes tags across all three repos at milestone close expecting zero CI from them. `'**'` matches every branch and no tags, preserving that property.
- **Added a `concurrency` group** — beyond the literal ask, so say if you'd rather drop it. A same-repo PR branch now matches both `push` and `pull_request`, so stale runs are superseded per ref instead of both being queued to completion. `cancel-in-progress` is explicitly **false** on main and beta: those runs are what the publishing workflows are judged against, and a cancelled gate reads as a failed gate. Motivation: three runs were cancelled by queue starvation earlier today with zero steps executed, which `gh pr checks` rendered as "fail".

**This PR tests itself**: pushing the branch fires the new trigger, so the run on this branch is the evidence the change works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)