### PR TITLE
ci: cut an app pre-release on every merge to beta

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,17 +1,28 @@
 name: Create a new beta pre-release
 on:
+  # EVERY merge to beta cuts a pre-release. The paths-ignore list that used to
+  # sit here ('**.md', '**.sh', '.gitignore', 'docs/**', 'images/**',
+  # '.github/**', '.vscode/**', 'tools/**') meant a merge touching only those
+  # paths bumped no version and published nothing, so beta silently stopped
+  # tracking its own branch. PR #46 hit exactly that: a .github/** change
+  # merged to beta and produced no pre-release at all, while the firmware repo
+  # -- whose equivalent list has no '.github/**' entry -- did cut one from the
+  # same class of change. The two repos disagreed about what beta means.
+  #
+  # Constant version bumping on beta is explicitly fine (operator decision):
+  # beta is a moving pre-release channel, not a curated one, so a version that
+  # advances on every merge is the desired behaviour rather than noise. The
+  # cost of the old filter -- a published beta that does not correspond to any
+  # beta commit -- is far worse than an extra version number.
+  #
+  # No publish loop: the "Commit updated version" step below uses
+  # git-auto-commit-action with the default GITHUB_TOKEN, and pushes made with
+  # GITHUB_TOKEN do not trigger workflow runs. Confirmed empirically in the
+  # firmware repo, where the equivalent auto-commit landed on beta and started
+  # no second run.
   push:
     branches:
     - beta
-    paths-ignore:
-    - '**.md'
-    - '**.sh'
-    - '.gitignore'
-    - 'docs/**'
-    - 'images/**'
-    - '.github/**'
-    - '.vscode/**'
-    - 'tools/**'
   workflow_dispatch:
     inputs:
       beta_version:


### PR DESCRIPTION
## The bug

`beta-release.yml` carried a `paths-ignore` list:

```
'**.md'  '**.sh'  '.gitignore'  'docs/**'  'images/**'  '.github/**'  '.vscode/**'  'tools/**'
```

A merge touching **only** those paths bumped no version and published nothing — so the published beta silently stopped corresponding to the beta branch.

#46 hit exactly this: a `.github/**` change merged to beta and produced **no pre-release**, while the firmware repo — whose equivalent list has no `.github/**` entry — cut `3.0.0b16` from the same class of change. The two repos disagreed about what beta means, and the app's answer was the wrong one. A beta channel that silently skips releases is worse than one whose version advances more often than strictly necessary.

## The fix

The filter is removed. Every merge to beta now bumps the version and publishes a pre-release.

## Verified, not assumed

- **The version bump was never broken.** `is_beta_mode()` keys off `GITHUB_REF == refs/heads/beta`. Under that environment the script computes `3.0.0b17` from the current `3.0.0b16`:
  ```
  $ GITHUB_REF=refs/heads/beta .github/scripts/update_version.py --dry-run
  DRY_RUN: 3.0.0b17
  ```
  The trigger was suppressing the whole job before the bump could run.

- **`fetch-depth: 0` is already set** on Checkout, which `compute_beta_version()`'s tag-scan fallback needs. No repeat of the shallow-clone defect found in the firmware's `build.yml` (henols/firestarter#50).

- **No publish loop.** `Commit updated version` uses `git-auto-commit-action` with the default `GITHUB_TOKEN`, and pushes made with `GITHUB_TOKEN` do not trigger workflow runs. Confirmed empirically in the firmware repo, where the equivalent auto-commit (`Apply automatic changes`) landed on beta and started no second run.

- `actionlint` clean.

## Consequence worth stating

Docs-only and tooling-only merges to beta will now also cut a pre-release. That is the intent — beta is a moving pre-release channel, and constant version bumping there is explicitly acceptable.

## Not covered here

The firmware's `beta-build.yml` still ignores `'**.md'`, `'**.sh'`, `docs/**`, `documents/**`, `images/**`, `.vscode/**`, `.editorconfig/**`. It publishes on `.github/**` changes (which is why b16 exists) but a **docs-only** merge to firmware beta still cuts nothing. Aligning it is a one-line deletion in the other repo — deliberately left out of this PR, which is scoped to the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)