### PR TITLE
ci: publish beta pre-releases to PyPI automatically

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -35,6 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # Exposed so the pypi job below can check out the exact tag this run
+    # created, rather than re-deriving it and risking a mismatch.
+    outputs:
+      version: ${{ steps.version.outputs.version }}
 
     steps:
       - name: Checkout
@@ -106,3 +110,25 @@ jobs:
           make_latest: false
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+  # Upload the pre-release to PyPI.
+  #
+  # This exists because the release.published event does NOT reach publish.yml
+  # for betas: the Release step above creates the release with
+  # secrets.PERSONAL_ACCESS_TOKEN, and that PAT lacks `workflow` scope, so
+  # GitHub suppresses the downstream event. The failure was silent -- GitHub
+  # reached b17 while PyPI stopped at b15, and nothing reported an error.
+  #
+  # Calling publish.yml directly removes the dependency on event delivery and
+  # on any credential's scope. `needs: github` orders this after the tag
+  # exists, and the tag is taken from that job's output rather than re-derived,
+  # so the upload cannot drift from the release.
+  #
+  # secrets: inherit satisfies publish.yml's required PYPI_API_TOKEN without
+  # naming it here.
+  pypi:
+    needs: github
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag: ${{ needs.github.outputs.version }}
+    secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,35 @@
 name: Publish to PyPI.org
 on:
+  # Stable path. release.yml creates the stable release with GITHUB_TOKEN and
+  # this event delivers, which is why GitHub 2.0.7 and PyPI 2.0.7 agree.
   release:
     types: [published]
-  # workflow_dispatch added 2026-05-20 (Phase 20 E2E-01 recovery): when a
-  # release is created by another workflow (e.g. beta-release.yml) using a
-  # PAT that lacks `workflow` scope, GitHub suppresses the release.published
-  # event from triggering downstream workflows. This manual trigger lets
-  # the operator re-publish to PyPI for a specific tag without modifying
-  # the stable-path automatic trigger above.
+
+  # Beta path (added because the event above does NOT deliver for betas).
+  # beta-release.yml creates its release with secrets.PERSONAL_ACCESS_TOKEN,
+  # and that PAT lacks `workflow` scope, so GitHub suppresses the resulting
+  # release.published event. The symptom was silent and long-lived: GitHub had
+  # betas through b17 while PyPI stopped at b15, with b16/b17 never uploaded
+  # and nothing anywhere reporting a failure.
+  #
+  # workflow_call rather than widening the PAT's scope. Adding `workflow` to
+  # the PAT would also work, but it is a long-lived, broadly-scoped credential
+  # whose expiry would silently recreate this exact failure -- the same class
+  # of bug, deferred. A reusable-workflow call depends on no credential and no
+  # event delivery at all: beta-release.yml invokes this file directly, so if
+  # the release is cut, the upload runs.
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag to publish to PyPI (e.g. 3.0.0b17).'
+        required: true
+        type: string
+    secrets:
+      PYPI_API_TOKEN:
+        required: true
+
+  # Retained as the operator escape hatch: re-publish a specific tag by hand
+  # (for example the b16/b17 backfill) without touching either automatic path.
   workflow_dispatch:
     inputs:
       tag:
@@ -22,12 +44,32 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # For workflow_dispatch: check out the specified tag.
-          # For release: published: leave default (the release's commit).
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          # `inputs` (not `github.event.inputs`) is deliberate: that context is
+          # populated for BOTH workflow_dispatch and workflow_call, whereas
+          # github.event.inputs covers dispatch only and would resolve to null
+          # on a workflow_call, silently checking out github.ref -- which for a
+          # called workflow is the CALLER's branch, not the release tag. The
+          # build would then publish beta HEAD under the tag's version number.
+          # On release: published `inputs` is empty and github.ref is the
+          # release's own ref, which is the correct fallback.
+          ref: ${{ inputs.tag || github.ref }}
       - run: python3 -m pip install --upgrade build && python3 -m build
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+          # Idempotent upload. This workflow now has two automatic entry points
+          # (release.published for stable, workflow_call for beta) plus the
+          # manual dispatch, so the same version can legitimately be attempted
+          # twice: re-running a failed beta-release job, or a future widening
+          # of PERSONAL_ACCESS_TOKEN's scope making release.published deliver
+          # alongside the call. PyPI rejects a duplicate upload with a hard
+          # 400, which would turn a successful release into a red run and, on
+          # a re-run, block recovery. skip-existing turns that into a no-op.
+          #
+          # Trade-off accepted knowingly: it also masks a genuine
+          # version-collision bug (the bump script emitting a version already
+          # on PyPI). The GitHub tag would collide first and fail louder, so
+          # that case is not silent overall.
+          skip-existing: true
 #          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
## The bug

```
GitHub releases : ... b15   b16   b17
PyPI            : ... b15    —     —
```

b16 and b17 were never uploaded, and **nothing anywhere reported a failure**.

**Root cause:** `beta-release.yml`'s Release step creates the release with `secrets.PERSONAL_ACCESS_TOKEN`, and that PAT lacks `workflow` scope — so GitHub suppresses the resulting `release.published` event and `publish.yml` never runs.

`publish.yml`'s own header comment predicted this back in May. The `workflow_dispatch` escape hatch added then is the only reason b11/b13/b14/b15 are on PyPI at all — each was an operator dispatching by hand, and the ones nobody remembered to dispatch simply went missing.

The **stable path is unaffected**: `release.yml` uses `GITHUB_TOKEN`, the event delivers, and GitHub `2.0.7` == PyPI `2.0.7`.

## Why `workflow_call` and not a wider PAT

Adding `workflow` scope to the PAT would also work and needs no code change. I chose against it: a PAT is a long-lived, broadly-scoped credential, and its expiry would **silently recreate this exact failure** — the same bug, deferred, and just as invisible. Trading one silent-expiry dependency for another isn't a fix.

A reusable-workflow call depends on no credential scope and no event delivery. If the release is cut, the upload runs.

```
publish.yml       + workflow_call (tag input, PYPI_API_TOKEN secret)
beta-release.yml  + pypi job: needs: github, uses: ./.github/workflows/publish.yml
                    tag from the github job's output
```

## Three details that matter

- **Tag comes from `needs.github.outputs.version`**, not re-derived — the upload cannot drift from the release it belongs to.

- **`inputs.tag`, not `github.event.inputs.tag`.** That context is populated for *both* `workflow_dispatch` and `workflow_call`; `github.event.inputs` covers dispatch only and would resolve to null on a call, silently falling back to `github.ref` — which for a called workflow is the **caller's branch, not the tag**. The build would then publish beta HEAD under the tag's version number. This is the subtle one.

- **`skip-existing: true`.** There are now two automatic entry points plus the manual one, so the same version can legitimately be attempted twice (re-running a failed job, or a future PAT scope widening making both paths fire). PyPI rejects duplicates with a hard 400, which would turn a good release red and block re-run recovery. Trade-off accepted knowingly: it also masks a genuine version-collision bug — but the GitHub tag would collide first and fail louder, so that case isn't silent overall.

## Not backfilled

b16 and b17 stay absent from PyPI. Both were CI-only changes with no functional content, so the gap carries nothing. Dispatch `Publish to PyPI.org` per tag if you want a complete index.

`actionlint` clean across all workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)