### PR TITLE
fix(dev test): run blank-check after erase for electrically erasable parts

### DIFF
--- a/firestarter/chip_test.py
+++ b/firestarter/chip_test.py
@@ -311,6 +311,24 @@ _PROTOCOL_FLASH4 = 0x05
 # bare literal.
 _PROTOCOL_EEPROM_28C = 0x0D
 
+# Quick task 260807-kaq: the two protocols whose FAMILY auto-erases per page
+# during the write itself, so no step in a "full"/"partial" plan can EVER
+# leave the device blank -- there is no erase op for blank-check to sit
+# behind, and a supported blank-check here would report chip state, not
+# tool health (the same defect this task exists to fix, wearing a different
+# hat). Measured against the live DB (746 chips, kaq_buckets.py): 111 chips
+# carry one of these two protocols (66 EEPROM + 18 Flash/EEPROM on 0x0D, 27
+# Flash/EEPROM on 0x05) -- all 111 have FLAG_CAN_ERASE clear by construction
+# (database.py:582-595 clears it for exactly these protocols), so this set
+# never overlaps the executable-erase case below. Deliberately narrow rather
+# than the broader "non-UV, no erase step" predicate: measured residual
+# outside this set (76 chips, all SRAM/FRAM) is already, and separately,
+# routed to NA by the SRAM/FRAM branch below BEFORE this predicate is ever
+# reached -- so the narrow and broad predicates coincide with zero measured
+# cost, and the narrow set is strictly safer against a future OTP/PROM-like
+# DB addition that would need its pre-write blank-check kept visible.
+_AUTO_ERASE_ON_WRITE_PROTOCOLS = frozenset({_PROTOCOL_FLASH4, _PROTOCOL_EEPROM_28C})
+
 # SRAM/FRAM electrical types and protocol ids: blank-check has no meaningful
 # concept for volatile/byte-rewritable memory. derive_plan owns this NA
 # decision up front (RESEARCH nuance recommendation (a)) rather than relying
@@ -586,23 +604,70 @@ def derive_plan(name: str, db: Any, *, write_scope: str = "none") -> Plan:
     # read / verify: always supported -- every protocol reads.
     steps.append(Step(op=OP_READ, supported=True, reason=""))
 
-    # blank-check: NA for SRAM/FRAM (derive_plan owns this decision up
-    # front, mirroring check_eprom_blank's own short-circuit by BOTH
-    # electrical-type and protocol-id, since the programmer dict passed to
-    # the operator lacks those keys -- RESEARCH § nuance recommendation a).
+    # erase_is_executable (quick task 260807-kaq): the SINGLE boolean deciding
+    # whether the supported OP_ERASE Step below actually gets appended --
+    # consumed a second time, read-only, by the blank-check placement logic
+    # immediately below, so the two decisions can never drift apart. Mirrors
+    # the erase arm's own supported condition (can_erase and protocol !=
+    # _PROTOCOL_FLASH4) narrowed by write_execute, since an erase step that is
+    # merely advisory (locked_destructive, write_scope="none") never actually
+    # runs -- there is nothing for blank-check to sit behind.
+    erase_is_executable = can_erase and protocol != _PROTOCOL_FLASH4 and write_execute
+
+    # blank-check (quick task 260807-kaq): a blank-check verdict is only
+    # meaningful once SOMETHING in this plan can actually leave the device
+    # blank. Built into a local Step here and appended at ONE of two possible
+    # positions below -- never both -- so the SDP leg block (appended last,
+    # unconditionally) always stays a contiguous terminal block regardless of
+    # where blank-check itself lands:
+    #   1. SRAM/FRAM -- NA, unchanged position/reason (volatile/byte-
+    #      rewritable memory has no factory-blank state at all; mirrors
+    #      check_eprom_blank's own short-circuit by BOTH electrical-type and
+    #      protocol-id, since the programmer dict passed to the operator
+    #      lacks those keys -- RESEARCH § nuance recommendation a).
+    #   2. erase_is_executable -- supported=True, but appended AFTER the
+    #      erase step (below) instead of here: only once erase has actually
+    #      run does "not blank" become a real, actionable tool-health
+    #      finding rather than a report of the chip's pre-existing state.
+    #   3. write_execute and protocol in _AUTO_ERASE_ON_WRITE_PROTOCOLS --
+    #      NA at this original position: no step in this plan can EVER
+    #      leave the device blank (each page write auto-erases internally),
+    #      so a supported blank-check here would report chip state, not
+    #      tool health -- the same defect wearing a different hat.
+    #   4. Everything else (UV-EPROM at any scope, every write_scope="none"
+    #      plan, any non-UV/non-erasable part outside case 3) -- unchanged:
+    #      supported=True at this original position. UV-EPROM in particular
+    #      keeps its blank-check HERE deliberately: the write is
+    #      irrecoverable and only UV light erases, so "not blank" is a real,
+    #      operator-actionable pre-write finding, not a false failure.
     if etype in _SRAM_FRAM_ETYPES or protocol in _SRAM_PROTO_IDS:
-        steps.append(
-            Step(
-                op=OP_BLANK_CHECK,
-                supported=False,
-                reason=(
-                    f"blank-check not applicable to {etype or 'unknown'} "
-                    "(volatile/byte-rewritable, no factory-blank state)"
-                ),
-            )
+        blank_check_step = Step(
+            op=OP_BLANK_CHECK,
+            supported=False,
+            reason=(
+                f"blank-check not applicable to {etype or 'unknown'} "
+                "(volatile/byte-rewritable, no factory-blank state)"
+            ),
+        )
+    elif write_execute and protocol in _AUTO_ERASE_ON_WRITE_PROTOCOLS:
+        family = (
+            "0x0D (28C family)" if protocol == _PROTOCOL_EEPROM_28C else "0x05 (flash4)"
+        )
+        blank_check_step = Step(
+            op=OP_BLANK_CHECK,
+            supported=False,
+            reason=(
+                f"protocol {family} auto-erases per page during write; no "
+                "step in this plan can ever leave the device blank"
+            ),
         )
     else:
-        steps.append(Step(op=OP_BLANK_CHECK, supported=True, reason=""))
+        blank_check_step = Step(op=OP_BLANK_CHECK, supported=True, reason="")
+
+    if not erase_is_executable:
+        # Cases 1/3/4 above: no erase step will run, so blank-check keeps
+        # its historic position (right after read, before write).
+        steps.append(blank_check_step)
 
     # write: always supported, always flagged destructive. When
     # write_scope="none" the step is OMITTED from the executable `steps`
@@ -632,9 +697,12 @@ def derive_plan(name: str, db: Any, *, write_scope: str = "none") -> Plan:
     # preceding write on a non-executing run, so a bare verify would compare
     # a freshly-generated pattern against unrelated chip contents).
     # Positioned after write and before erase so the destructive step order
-    # (write, verify, erase) is unchanged. Its write_region equals the write
-    # step's -- a verify's region is definitionally the preceding write's
-    # (D-07).
+    # (write, verify, erase) is UNCHANGED by this task -- but a blank-check
+    # may now follow the erase step (see erase_is_executable above): once
+    # something in the plan can leave the device blank, blank-check doubles
+    # as that step's own oracle instead of reporting pre-existing chip
+    # state. Its write_region equals the write step's -- a verify's region
+    # is definitionally the preceding write's (D-07).
     if write_execute:
         steps.append(
             Step(op=OP_VERIFY, supported=True, reason="", write_region=write_region)
@@ -648,9 +716,17 @@ def derive_plan(name: str, db: Any, *, write_scope: str = "none") -> Plan:
     # (flash4 auto-erases per page; the flag is deliberately clear for it --
     # Pitfall 6). UV-EPROM never has the flag set (electrical-type is not in
     # {EEPROM, Flash/EEPROM}) so it is NA here for the same condition.
+    # `erase_is_executable` (computed once, above, and reused verbatim here)
+    # is exactly `can_erase and protocol != _PROTOCOL_FLASH4 and
+    # write_execute` -- never re-derived, so this arm and the blank-check
+    # placement decision can never drift apart.
     if can_erase and protocol != _PROTOCOL_FLASH4:
-        if write_execute:
+        if erase_is_executable:
             steps.append(Step(op=OP_ERASE, supported=True, reason="", destructive=True))
+            # Case 2 (above): blank-check now follows the erase step it
+            # doubles as an oracle for, and precedes the SDP leg block
+            # appended below -- the leg stays a contiguous terminal block.
+            steps.append(blank_check_step)
         else:
             locked_destructive.append(
                 (OP_ERASE, 'write_scope="none": erase omitted (D-01)')

--- a/tests/test_chip_test.py
+++ b/tests/test_chip_test.py
@@ -594,18 +594,24 @@ def test_derive_plan_destructive_flag_strips_not_annotates():
 
     # Recorded op sequences (SUMMARY): write_scope="none" ->
     # ["id", "read", "blank-check"]; write_scope="full" ->
-    # ["id", "read", "blank-check", "write", "verify", "erase"] plus the
-    # six SDP-leg NA ops (LEG-02, this phase) -- identical to the
-    # pre-121-05 destructive=False/True sequences for this chip PLUS the
-    # new appended block.
+    # ["id", "read", "write", "verify", "erase", "blank-check"] plus the
+    # six SDP-leg NA ops (LEG-02, this phase).
+    #
+    # Quick task 260807-kaq moved this assertion's write_scope="full" order:
+    # M8720 has an executable erase step (protocol 0x08, FLAG_CAN_ERASE set),
+    # so blank-check now runs AFTER erase instead of before write -- it
+    # doubles as erase's own oracle instead of reporting the chip's
+    # pre-existing (pre-erase) state as a false BAD. write_scope="none" is
+    # UNCHANGED: no erase step is ever executable there (case 2 requires
+    # write_execute), so blank-check keeps its historic position.
     assert ops_default == ["id", "read", "blank-check"]
     assert ops_destructive == [
         "id",
         "read",
-        "blank-check",
         "write",
         "verify",
         "erase",
+        "blank-check",
         *_SDP_LEG_STEP_ORDER,
     ]
     sdp_steps = [s for s in plan_destructive.steps if s.op in _SDP_LEG_STEP_ORDER]
@@ -2260,35 +2266,37 @@ def _gated_allow_operator():
 def test_count_applicable_sdp_gated_allow_chip_ratio_drops():
     """LEG-13's pinning test. For AT28C256 (a measured ALLOW chip) at
     `write_scope="full"` with the oracle gated (the dead-write-path shape,
-    gh#20's own bench), `count_applicable` measures `m_applicable == 10`
+    gh#20's own bench), `count_applicable` measures `m_applicable == 9`
     (the six SDP steps carry `supported=True` and are already counted in
-    M -- `id`/`erase` are the only two NA steps on this chip, so
-    4 shipped + 6 SDP = 10) and `n_ran == 6` (four shipped ops plus
-    `write-baseline-a`, which is never itself gated and reports OK against
-    this fixture, ran; the four `_SDP_LEG_GATED_OPS` members SKIP).
+    M -- `id`/`erase`/`blank-check` are the three NA steps on this chip, so
+    3 shipped + 6 SDP = 9) and `n_ran == 5` (three shipped ops [read, write,
+    verify] plus `write-baseline-b`/`write-baseline-a`, which reports BAD/OK
+    respectively and both count as ran; the four `_SDP_LEG_GATED_OPS`
+    members SKIP).
 
     MEASURED DISCREPANCY, carried forward rather than silently reconciled
     (the same project convention 134-04-SUMMARY.md and 134-07-SUMMARY.md
     both already recorded for this identical computation): 134-CONTEXT.md
     D-20 and this plan's own text state the dead-write-path shape produces
-    `n_ran=5`. The ACTUAL measured value, run live against AT28C256 with
-    this dead-write-path operator, is `n_ran=6` -- because
-    `write-baseline-a` is never itself gated by `_baseline_closes_sdp_gate`
-    (only the FOUR downstream `_SDP_LEG_GATED_OPS` members are skipped once
-    the gate closes, per 134-04's own design), and this fixture's read-back
-    always matches pattern A, so `write-baseline-a` reports OK and counts
-    as ran. This does NOT affect LEG-13's own claim -- the headline ratio
-    still DROPS, from today's misleading "4 of 4" to "6 of 10" under this
-    leg -- only the specific numeral quoted in 134-CONTEXT.md/the plan's
-    own prose, which this test does not restate as though it were correct.
+    `n_ran=5`, matching the CURRENT measured value below -- but this
+    coincidence is itself an M/N delta, not a restored agreement: before
+    quick task 260807-kaq's blank-check fix, this same fixture measured
+    `n_ran=6, m_applicable=10` (blank-check was a real supported step here,
+    since AT28C256 is protocol 0x0D and 260807-kaq had not yet flipped it to
+    NA-by-family-fact). 260807-kaq's fix removes blank-check from BOTH M and
+    N for this chip (case 3: protocol 0x0D auto-erases per page during
+    write, so no step in this plan can ever leave the device blank) --
+    `m_applicable` drops 10 -> 9, `n_ran` drops 6 -> 5. This does NOT affect
+    LEG-13's own claim -- the headline ratio still DROPS, now from today's
+    misleading "4 of 4" to "5 of 9" under this leg.
     """
     plan = derive_plan("AT28C256", _REAL_DB, write_scope="full")
     operator = _gated_allow_operator()
     results = run_plan(plan, operator, _REAL_DB)
 
     counts = count_applicable(plan, results)
-    assert counts.m_applicable == 10, counts
-    assert counts.n_ran == 6, counts  # measured, not the stated 5 -- see docstring
+    assert counts.m_applicable == 9, counts  # 260807-kaq: M dropped 10 -> 9
+    assert counts.n_ran == 5, counts  # 260807-kaq: N dropped 6 -> 5
     assert counts.n_ran < counts.m_applicable, counts  # the ratio drops (LEG-13)
 
     write_baseline_b = _result(results, "write-baseline-b")
@@ -2365,7 +2373,11 @@ def test_count_applicable_sdp_banner_row_renders_the_dropped_ratio():
     operator = _gated_allow_operator()
     results = run_plan(plan, operator, _REAL_DB)
     banner = count_applicable(plan, results)
-    assert banner.n_ran == 6 and banner.m_applicable == 10  # see the docstring above
+    # 260807-kaq: n_ran/m_applicable dropped 6/10 -> 5/9 -- blank-check is
+    # now NA (not a real step) for this protocol-0x0D chip. See the
+    # docstring above on `test_count_applicable_sdp_gated_allow_chip_ratio_
+    # drops` for the full M/N delta accounting.
+    assert banner.n_ran == 5 and banner.m_applicable == 9  # see the docstring above
 
     auto_capture = AutoCapture(
         host_version=firestarter.__version__, chip="AT28C256", protocol="0x0D"

--- a/tests/test_chip_test_blank_check_order.py
+++ b/tests/test_chip_test_blank_check_order.py
@@ -1,0 +1,144 @@
+"""
+Project Name: Firestarter
+Copyright (c) 2024 Henrik Olsson
+
+Permission is hereby granted under MIT license.
+
+Quick task 260807-kaq: `dev test` blank-check must run AFTER erase.
+
+Unit-level ordering proof for `derive_plan`'s conditional blank-check
+placement rule (see `<placement_rule>` in the quick task's PLAN.md). All
+four placement cases are covered against the REAL on-disk chip database
+(the same `EpromDatabase(skip_local_override=True)` idiom
+`tests/test_chip_test.py`'s `_REAL_DB` fixture uses -- no serial I/O, no
+mocking of the database itself):
+
+  1. M8720 (protocol 0x08, EEPROM, FLAG_CAN_ERASE set) -- an executable
+     erase step exists, so blank-check moves to AFTER erase and BEFORE the
+     SDP leg's six-op contiguous terminal block.
+  2. M8720, write_scope="none" -- untouched: no erase step is ever
+     executable at write_scope="none" (case 2 requires write_execute), so
+     blank-check stays at its historic position.
+  3. AM27512 (UV-EPROM) -- untouched: a pre-write blank-check is genuinely
+     actionable on an irrecoverable UV write, so case 4 applies regardless
+     of write_scope.
+  4. AT28C256 (protocol 0x0D, 28C family) -- flips to an NA blank-check
+     with a family-fact reason (each page write auto-erases internally),
+     never the flag name.
+
+This module was written and observed RED against the unmodified
+`chip_test.py` BEFORE the fix landed (Task 2, TDD RED gate) -- see
+260807-kaq-SUMMARY.md for the captured failure output.
+"""
+
+from firestarter.chip_test import (
+    _SDP_LEG_STEP_ORDER,  # test-internal: the D-06 six-op order (v1.30 Phase 134)
+    OP_BLANK_CHECK,
+    OP_ERASE,
+    OP_ID,
+    OP_READ,
+    derive_plan,
+)
+from firestarter.database import EpromDatabase
+
+# A real, on-disk-database instance (skip_local_override=True: no
+# ~/.firestarter override, no serial) -- the same module-level idiom
+# tests/test_chip_test.py's `_REAL_DB` fixture uses.
+_REAL_DB = EpromDatabase(skip_local_override=True)
+
+# M8720: protocol 0x08, electrical-type EEPROM, FLAG_CAN_ERASE set -- the
+# established erasable fixture across this suite (see tests/test_chip_test.py
+# and tests/test_dev_test_cmd.py's own fixture comments). Gets a REAL,
+# executable erase step at write_scope="full".
+_CHIP_ERASABLE = "M8720"
+# AM27512: electrical-type UV-EPROM (is_uv_eprom exact axis). A pre-write
+# blank-check here is genuinely actionable -- the write is irrecoverable and
+# only UV light erases.
+_CHIP_UV = "AM27512"
+# AT28C256: protocol 0x0D (EEPROM_POLL / 28C family) -- auto-erases per page
+# during write, so FLAG_CAN_ERASE is clear and no erase step is ever
+# executable for it. Also one of the v1.30 SDP-ALLOW chips (43/84), so its
+# write_scope="full" plan carries the six-step SDP leg too.
+_CHIP_AUTO_ERASE_28C = "AT28C256"
+
+
+def test_m8720_full_blank_check_moves_after_erase_before_sdp_leg():
+    """Case 2: an executable erase step exists, so blank-check moves to
+    immediately after it -- and the SDP leg (M8720 is a measured REFUSE
+    chip, so its six ops are NA here, D-06/LEG-02) stays a contiguous
+    terminal block strictly after blank-check."""
+    plan = derive_plan(_CHIP_ERASABLE, _REAL_DB, write_scope="full")
+    ops = [s.op for s in plan.steps]
+
+    assert OP_ERASE in ops, "fixture setup error: M8720 must have an erase step"
+    assert OP_BLANK_CHECK in ops
+
+    blank_check_index = ops.index(OP_BLANK_CHECK)
+    erase_index = ops.index(OP_ERASE)
+    assert blank_check_index > erase_index, (
+        f"blank-check (index {blank_check_index}) must run AFTER erase "
+        f"(index {erase_index}) on an erasable part"
+    )
+
+    blank_check_step = next(s for s in plan.steps if s.op == OP_BLANK_CHECK)
+    assert blank_check_step.supported is True
+
+    for sdp_op in _SDP_LEG_STEP_ORDER:
+        assert sdp_op in ops, f"fixture setup error: SDP leg op {sdp_op!r} missing"
+        sdp_index = ops.index(sdp_op)
+        assert sdp_index > blank_check_index, (
+            f"SDP leg op {sdp_op!r} (index {sdp_index}) must stay strictly "
+            f"after blank-check (index {blank_check_index}) -- the leg must "
+            "remain a contiguous terminal block"
+        )
+
+
+def test_m8720_write_scope_none_is_unchanged():
+    """Case 2 requires write_execute (an erase step is only ever
+    'executable' when it was actually appended as a real step) -- at
+    write_scope="none" no erase step runs, so blank-check stays at its
+    historic position and the untouched-scope proof holds byte-for-byte."""
+    plan = derive_plan(_CHIP_ERASABLE, _REAL_DB, write_scope="none")
+    assert [s.op for s in plan.steps] == [OP_ID, OP_READ, OP_BLANK_CHECK]
+
+    locked_ops = {op for op, _reason in plan.locked_destructive}
+    assert locked_ops == {"write", "verify", "erase"}
+
+
+def test_am27512_uv_blank_check_position_is_unchanged():
+    """Case 4/UV: a pre-write blank-check is genuinely actionable on an
+    irrecoverable UV write, so its index and supported status stay exactly
+    as they were before this fix."""
+    plan = derive_plan(_CHIP_UV, _REAL_DB, write_scope="full")
+    ops = [s.op for s in plan.steps]
+    assert ops.index(OP_BLANK_CHECK) == 2
+
+    blank_check_step = next(s for s in plan.steps if s.op == OP_BLANK_CHECK)
+    assert blank_check_step.supported is True
+
+
+def test_at28c256_blank_check_is_na_with_family_fact_reason():
+    """Case 3: protocol 0x0D auto-erases per page during write -- no step
+    in this plan can ever leave the device blank, so blank-check flips to
+    NA at its original position (index 2) with a family-fact reason, never
+    the internal flag name FLAG_CAN_ERASE."""
+    plan = derive_plan(_CHIP_AUTO_ERASE_28C, _REAL_DB, write_scope="full")
+    ops = [s.op for s in plan.steps]
+    assert ops.index(OP_BLANK_CHECK) == 2
+
+    blank_check_step = next(s for s in plan.steps if s.op == OP_BLANK_CHECK)
+    assert blank_check_step.supported is False
+    assert "FLAG_CAN_ERASE" not in blank_check_step.reason
+    assert "0x0d" in blank_check_step.reason.lower() or "28c" in (
+        blank_check_step.reason.lower()
+    )
+
+
+def test_m8720_full_plan_has_exactly_one_blank_check_and_one_erase_step():
+    """Non-vacuity leg: the index comparisons above cannot pass by accident
+    on a duplicated op -- M8720's write_scope="full" plan has exactly one
+    OP_BLANK_CHECK step and exactly one OP_ERASE step."""
+    plan = derive_plan(_CHIP_ERASABLE, _REAL_DB, write_scope="full")
+    ops = [s.op for s in plan.steps]
+    assert ops.count(OP_BLANK_CHECK) == 1
+    assert ops.count(OP_ERASE) == 1

--- a/tests/test_chip_test_sdp_leg.py
+++ b/tests/test_chip_test_sdp_leg.py
@@ -2260,21 +2260,31 @@ def test_baseline_gate_closes_dead_write_path_allow_chip_full_leg():
     ⚠ MEASURED DISCREPANCY, recorded rather than silently reconciled (same
     project convention as 134-02-SUMMARY.md's "exactly two" finding):
     134-CONTEXT.md D-20 and this plan's own <behavior>/<action> text state
-    `n_ran=5, m_applicable=10` for this exact scenario. The ACTUAL measured
-    value, run live against this commit's `_dead_write_path_operator()`
-    fixture, is `n_ran=6, m_applicable=10` -- because `write-baseline-a`
-    (unlike the four `_SDP_LEG_GATED_OPS` members) is NEVER itself gated by
-    `baseline_gate_closed`: both baseline directions always run regardless
-    of the gate's state, since they are what DECIDE it (D-08's own
-    stickiness requirement -- see `test_baseline_gate_sticky_...` below --
-    is unsatisfiable if baseline-a does not run at all once the gate is
-    closed). `write-baseline-a` against this fixture reports OK (its
-    expected read-back is pattern A, and the fixture's `read_eprom` always
-    returns pattern A), so it counts as "ran" alongside the four shipped
-    ops (read/blank-check/write/verify) and `write-baseline-b` itself: 4 +
-    2 = 6 ran, 4 skipped, out of 10 applicable. This is the CORRECT,
-    measured value; the "5"/" five SKIPPED" figures elsewhere in the phase
-    record are the ones in error, not this assertion.
+    `n_ran=5, m_applicable=10` for this exact scenario. Before quick task
+    260807-kaq, the ACTUAL measured value, run live against this commit's
+    `_dead_write_path_operator()` fixture, was `n_ran=6, m_applicable=10` --
+    because `write-baseline-a` (unlike the four `_SDP_LEG_GATED_OPS`
+    members) is NEVER itself gated by `baseline_gate_closed`: both baseline
+    directions always run regardless of the gate's state, since they are
+    what DECIDE it (D-08's own stickiness requirement -- see
+    `test_baseline_gate_sticky_...` below -- is unsatisfiable if baseline-a
+    does not run at all once the gate is closed). `write-baseline-a` against
+    this fixture reports OK (its expected read-back is pattern A, and the
+    fixture's `read_eprom` always returns pattern A), so it counted as "ran"
+    alongside the four shipped ops (read/blank-check/write/verify) and
+    `write-baseline-b` itself: 4 + 2 = 6 ran, 4 skipped, out of 10
+    applicable.
+
+    260807-kaq's fix flips blank-check to NA for AT28C256 (protocol 0x0D,
+    case 3: no step in this plan can ever leave the device blank, since
+    each page write auto-erases internally) -- REMOVING it from both the
+    "ran" set and the applicable set. `m_applicable` drops 10 -> 9 (3
+    shipped-supported [read/write/verify] + 6 SDP-leg-supported, since id,
+    erase AND NOW blank-check are all NA for this chip) and `n_ran` drops
+    6 -> 5 (write-baseline-b/write-baseline-a plus the 3 shipped-supported
+    ops that ran, minus blank-check). These ARE the current, live-measured
+    values -- not a restoration of the stale 134-CONTEXT.md prose, which
+    predates both this task's fix AND the "exactly two" discrepancy above.
     """
     name = "AT28C256"
     allowed, _reason = sdp_capability(name, _REAL_DB)
@@ -2309,15 +2319,19 @@ def test_baseline_gate_closes_dead_write_path_allow_chip_full_leg():
     operator.sdp_lock.assert_not_called()
 
     counts = count_applicable(plan, results)
-    assert counts.n_ran == 6, (
-        f"measured n_ran={counts.n_ran}, expected 6 -- see this test's "
-        "MEASURED DISCREPANCY docstring; do not change this to 5 to match "
-        "134-CONTEXT.md D-20's prose without re-deriving the arithmetic"
+    assert counts.n_ran == 5, (
+        f"measured n_ran={counts.n_ran}, expected 5 -- 260807-kaq dropped "
+        "this from 6 (blank-check is now NA for this protocol-0x0D chip, "
+        "so it no longer counts as 'ran'); see this test's MEASURED "
+        "DISCREPANCY docstring; do not change this to match "
+        "134-CONTEXT.md D-20's stale prose without re-deriving the "
+        "arithmetic"
     )
-    assert counts.m_applicable == 10, (
-        f"measured m_applicable={counts.m_applicable}, expected 10 "
-        "(4 shipped-supported + 6 SDP-leg-supported, since id and erase "
-        "are both NA for this chip)"
+    assert counts.m_applicable == 9, (
+        f"measured m_applicable={counts.m_applicable}, expected 9 "
+        "(3 shipped-supported [read/write/verify] + 6 SDP-leg-supported, "
+        "since id, erase AND NOW blank-check (260807-kaq) are all NA for "
+        "this chip)"
     )
 
 

--- a/tests/test_dev_test_cmd.py
+++ b/tests/test_dev_test_cmd.py
@@ -1715,3 +1715,75 @@ class TestLaunderingRoutesR3R4:
         assert hold_state == f"{SDP_HOLD_NOT_RUN}: {expected_reason}", hold_state
         normalized = _normalize_console_text(result.output)
         assert f"sdp_hold_state {hold_state}" in normalized, normalized
+
+
+# ---------------------------------------------------------------------------
+# Quick task 260807-kaq: blank-check must run AFTER erase, end to end.
+# `pytest -k "blank_check_after_erase"` selects this class.
+# ---------------------------------------------------------------------------
+
+
+class TestBlankCheckAfterEraseKaq:
+    """End-to-end proof that a `dev test` run no longer scores a false BAD
+    verdict for a chip that merely held data at the moment blank-check used
+    to run (before any write/erase touched it).
+
+    This class was written and observed RED against the unmodified
+    `chip_test.py` (blank-check ran BEFORE erase, so the honest-simulation
+    closure below returned False and the run exited 1) -- see
+    260807-kaq-SUMMARY.md for the captured failure output.
+    """
+
+    def test_erasable_chip_blank_only_after_erase_exits_0(
+        self, runner: CliRunner
+    ) -> None:
+        """M8720 (an executable-erase chip): an honest simulation of a used
+        device that only becomes blank once erase has actually run --
+        `check_eprom_blank`'s closure returns `operator.erase_eprom.called`.
+        With blank-check now positioned AFTER erase, the closure observes
+        True and the step verdicts OK; the whole run exits 0."""
+        operator = make_clean_operator()
+
+        def _blank_only_after_erase(name: str, eprom_data: dict) -> bool:
+            return bool(operator.erase_eprom.called)
+
+        operator.check_eprom_blank.side_effect = _blank_only_after_erase
+        app = make_app_context(
+            eprom_operator=operator, hardware_manager=make_hardware_manager()
+        )
+        with _off_tty():
+            result = runner.invoke(cli, ["dev", "test", _CHIP_NO_ID], obj=app)
+        assert result.exit_code == 0, result.output
+        data = _load_report(_CHIP_NO_ID)
+        steps = {s["op"]: s for s in data["steps"]}
+        assert steps["blank-check"]["verdict"] == "OK", steps["blank-check"]
+
+    def test_auto_erase_on_write_chip_never_calls_blank_check_and_exits_0(
+        self, runner: CliRunner
+    ) -> None:
+        """AT28C256 (protocol 0x0D, 28C family): no step in this plan can
+        ever leave the device blank (each page write auto-erases
+        internally), so blank-check is emitted NA -- `run_plan` skips an
+        unsupported step WITHOUT any operator call. A non-blank device
+        (`check_eprom_blank.return_value = False`) must not matter at all:
+        the run still exits 0 and the operator method is never dispatched.
+
+        AT28C256 is also one of the 43 SDP-ALLOW chips, so its plan carries
+        the six-step SDP leg -- `make_held_lock_operator()` (this suite's
+        established clean-success ALLOW-chip double, see
+        `TestHoldStateLeg12` above) is used instead of `make_clean_operator()`
+        so the leg's own baseline/lock/inhibited/unlock/restore steps
+        genuinely succeed and do not confound this test's own exit-0
+        assertion with an unrelated SDP-leg BAD/NOT-HELD."""
+        operator = make_held_lock_operator()
+        operator.check_eprom_blank.return_value = False
+        app = make_app_context(
+            eprom_operator=operator, hardware_manager=make_hardware_manager()
+        )
+        with _off_tty():
+            result = runner.invoke(cli, ["dev", "test", _CHIP_ALLOW], obj=app)
+        assert result.exit_code == 0, result.output
+        data = _load_report(_CHIP_ALLOW)
+        steps = {s["op"]: s for s in data["steps"]}
+        assert steps["blank-check"]["verdict"] == "NA", steps["blank-check"]
+        operator.check_eprom_blank.assert_not_called()

--- a/tests/test_dev_test_cmd.py
+++ b/tests/test_dev_test_cmd.py
@@ -866,8 +866,18 @@ class TestAbsentChipHardFail:
         assert steps["id"]["verdict"] == "NA"
         assert steps["read"]["verdict"] == "SKIPPED"
         assert "adapter" in steps["read"]["reason"]
-        assert steps["blank-check"]["verdict"] == "SKIPPED"
-        assert "adapter" in steps["blank-check"]["reason"]
+        # Quick task 260807-kaq moved this assertion: AT28C16 is protocol
+        # 0x0D (28C family, measured), so derive_plan now emits blank-check
+        # as NA-by-family-fact (case 3, auto-erase-on-write) BEFORE run_plan
+        # ever reaches resolve_chip's adapter refusal -- blank-check no
+        # longer carries the adapter reason at all. "write" below remains
+        # this test's proof that the adapter-required guard still surfaces
+        # as SKIPPED, never a bare exit, on a step that DOES reach
+        # resolve_chip.
+        assert steps["blank-check"]["verdict"] == "NA"
+        assert "0x0d" in steps["blank-check"]["reason"].lower()
+        assert steps["write"]["verdict"] == "SKIPPED"
+        assert "adapter" in steps["write"]["reason"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The bug

`derive_plan` emitted `OP_BLANK_CHECK` at index 2 — **before** any erase:

```
ID → READ → BLANK_CHECK → WRITE → VERIFY → ERASE
```

On an electrically erasable part that merely holds data, the blank-check therefore ran against a full chip and failed for the expected state.

**It failed loudly, not softly.** A false `check_eprom_blank` maps to `VERDICT_BAD` (`chip_test.py:1601`), BAD maps to exit **1** (`cli_handlers.py:2011`), and `_EXIT_CODE_PRECEDENCE = (1, 2, 0)` makes 1 the *most severe* code `dev test` can emit. So a perfectly healthy erasable chip produced the worst possible exit.

## The fix — conditional placement, not a blanket move

A single shared boolean now drives both the erase arm and the blank-check placement:

```python
erase_is_executable = can_erase and protocol != _PROTOCOL_FLASH4 and write_execute
```

The step is *built* first, then placed. Four cases, in precedence order:

| case | behaviour |
|---|---|
| SRAM/FRAM | unchanged — condition and reason string byte-identical |
| executable erase present | blank-check moves to **after** erase; it becomes a deterministic assertion and doubles as erase's own oracle |
| `write_execute` and protocol ∈ `{0x05, 0x0D}` | stays at index 2 but flips to `supported=False` — these auto-erase per page, so **no step in such a plan can ever leave the device blank** |
| everything else | unchanged — covers UV-EPROM at any scope, and every `write_scope="none"` plan |

UV-EPROM keeps its pre-write blank-check deliberately: there, "not blank before an irrecoverable write" is a genuine, actionable fault.

## Measured, not assumed

Partitioned the live 746-chip database:

| bucket | definition | count |
|---|---|---|
| A | executable erase step present | 258 |
| B | UV-EPROM | 301 |
| C | `protocol ∈ {0x05, 0x0D}` — the new NA arm | 111 |
| D | residual | 76 |

Sum 746 ✓. **Bucket D turned out to be 100% SRAM/FRAM**, already routed to NA by an earlier branch before the new predicate is ever evaluated. That is the only place the narrow `{0x05, 0x0D}` predicate and a broader "non-UV, no erase step" predicate could differ — so the narrow one is strictly safer at zero measured cost. Recorded as a refinement rather than silently widening the rule.

## RED-first

`tests/test_chip_test_blank_check_order.py` (5 unit tests) plus `TestBlankCheckAfterEraseKaq` in `tests/test_dev_test_cmd.py` (2 end-to-end CliRunner tests). The E2E leg overrides `check_eprom_blank` with a closure returning `operator.erase_eprom.called` — an honest simulation of a used erasable device. Both observed **RED against unmodified `chip_test.py` for the right reason**, then green.

## Reconciliation

4 assertions moved and were updated (not deleted) — 3 in the predicted category, plus an unpredicted-but-consequential AT28C16 case. The destructive triple's relative order (write → verify → erase) is unchanged, so `d_ops.index(OP_VERIFY) < d_ops.index(OP_ERASE)` still holds.

**Suite: 1532 → 1539 passed.** `ruff check` and `ruff format --check` clean.

## Out of scope, noted

`dev_test`'s docstring at `cli_handlers.py:2404` still describes the superseded `max()` exit mechanism. Stale, deliberately untouched here.

Planning artifacts live in the meta repo on `quick/260807-kaq-blank-check-after-erase` (quick task `260807-kaq`); the submodule gitlink is deliberately not bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)