### PR TITLE
fix: restore the firmware-update path off old firmware, and make --port authoritative

### DIFF
--- a/firestarter/cli_handlers.py
+++ b/firestarter/cli_handlers.py
@@ -264,7 +264,10 @@ def build_arg_flags(args: object) -> int:
 
 def _maybe_auto_route_to_pre(args: object) -> None:
     """D-22 / D-25 beta-app magic default: when installed app is a pre-release,
-    bare 'fw -i' (no --pre, no --firmware-version) auto-routes to --pre channel.
+    any 'fw' invocation that pins no channel (no --pre, no --firmware-version,
+    no --stable) auto-routes to the --pre channel. ``args.install`` is NOT part
+    of the condition — see the comment on the guard below for the two defects
+    that gating on it caused.
 
     Relocated verbatim from main.py:211-249 per Phase 41 D-16. Signature is
     ``(args) -> None`` — NO logger parameter (Phase 18 revision warning #6).
@@ -279,11 +282,22 @@ def _maybe_auto_route_to_pre(args: object) -> None:
     D-24: explicit --firmware-version OR --stable opts out of this magic.
     """
     helper_logger = logging.getLogger(__name__)
-    if not (
-        getattr(args, "install", False)
-        and not getattr(args, "pre", False)
-        and not getattr(args, "firmware_version", None)
-        and not getattr(args, "stable", False)
+    # The condition is "the operator pinned no channel", NOT "the operator
+    # typed --install". Requiring --install made every OTHER fw invocation on
+    # a pre-release app resolve the STABLE channel:
+    #   * bare `fw` compared the installed firmware against the newest STABLE
+    #     firmware (2.0.6), so a beta app on beta firmware printed "already up
+    #     to date" and the newer beta firmware was invisible;
+    #   * `fw --force` — the documented reinstall escape hatch — resolved the
+    #     stable asset and would have DOWNGRADED the board to firmware this
+    #     host cannot speak to, bricking the pairing it was invoked to repair.
+    # D-23 (a stable-installed app is unaffected) and D-24 (--stable or
+    # --firmware-version opts out) are both unchanged: they are the other two
+    # clauses below and the is_prerelease test.
+    if (
+        getattr(args, "pre", False)
+        or getattr(args, "firmware_version", None)
+        or getattr(args, "stable", False)
     ):
         return
     try:

--- a/firestarter/config.py
+++ b/firestarter/config.py
@@ -195,6 +195,23 @@ class ConfigManager:
         else:
             self._transient_keys.add(key)
 
+    def remember_port(self, port_name: str) -> None:
+        """Record a port that just worked, for the next invocation's convenience.
+
+        The single writer of the saved "port" key, so the rule cannot drift: a
+        port the operator typed for THIS invocation is NEVER promoted into the
+        saved config. `--port` is documented as applying to one invocation, yet
+        two separate call sites used to persist it — the successful probe in
+        `serial_comm` and the successful flash in `firmware` — so
+        `~/.firestarter/config.json` silently acquired a `port` key from a
+        one-off `--port` and retargeted every later command. Now that a typed
+        port also RESTRICTS discovery, promoting it would strand them there too.
+
+        `tests/test_fw_port_targeting_and_blind_install.py` carries a source-level
+        tripwire asserting no production module writes the key directly.
+        """
+        self.set_value("port", port_name, persist=not self.is_transient("port"))
+
     def is_transient(self, key) -> bool:
         """True if `key` was set for this invocation only (persist=False).
 

--- a/firestarter/config.py
+++ b/firestarter/config.py
@@ -104,6 +104,13 @@ class ConfigManager:
             return
 
         self._config: dict[str, Any] = {}
+        # Keys set with persist=False. They live in _config so get_value sees
+        # them for this invocation, but _save_config must exclude them: a later
+        # persist=True write of an UNRELATED key (e.g. firmware.py caching
+        # "avrdude-path" after a successful flash) dumps the whole dict, which
+        # would otherwise make a one-shot `--port` stick forever and silently
+        # retarget every later command at that port.
+        self._transient_keys: set[str] = set()
         self._load_config()
         ConfigManager._initialized_configs[self.config_file_path] = True
         logger.debug(f"ConfigManager initialized for {self.config_file_path}.")
@@ -139,9 +146,12 @@ class ConfigManager:
                     f"Error: Unable to create configuration directory {HOME_PATH}: {e}"
                 )
                 return
+        persistable = {
+            k: v for k, v in self._config.items() if k not in self._transient_keys
+        }
         try:
             with open(self.config_file_path, "w") as f:
-                json.dump(self._config, f, indent=4)
+                json.dump(persistable, f, indent=4)
         except IOError as e:  # noqa: UP024
             logger.error(
                 f"Error: Unable to save configuration to {self.config_file_path}: {e}"
@@ -173,10 +183,28 @@ class ConfigManager:
                 self.remove_key(key)
             else:
                 self._config.pop(key, None)
+                self._transient_keys.discard(key)
             return
         self._config[key] = value
         if persist:
+            # An explicit persisted write promotes the key out of transient
+            # status — otherwise `config port X` would be silently discarded
+            # after a `--port Y` earlier in the same process.
+            self._transient_keys.discard(key)
             self._save_config()
+        else:
+            self._transient_keys.add(key)
+
+    def is_transient(self, key) -> bool:
+        """True if `key` was set for this invocation only (persist=False).
+
+        The discriminator between "the operator typed --port this run" and "a
+        port remembered from a previous successful run". The first is a command
+        and must be obeyed exactly; the second is a hint that has to yield to
+        discovery, or replugging a board would strand every later invocation on
+        a port that no longer exists.
+        """
+        return key in self._transient_keys
 
     def remove_key(self, key):
         """
@@ -184,6 +212,7 @@ class ConfigManager:
         Args:
             key (str): The configuration key to remove.
         """
+        self._transient_keys.discard(key)
         if key in self._config:
             del self._config[key]
             self._save_config()

--- a/firestarter/firmware.py
+++ b/firestarter/firmware.py
@@ -793,8 +793,24 @@ class FirmwareManager:
             )
             return False
 
-        # Use the port where firmware was checked, or CLI override for flashing
-        port_to_use = port_override or connected_port
+        # Flash the port the identity CAME FROM; fall back to the override only
+        # when nothing was identified (the blind-install path below).
+        #
+        # The order matters and used to be reversed (`port_override or
+        # connected_port`), which let the board and the target come from
+        # DIFFERENT ports: a port named on this invocation now restricts the
+        # probe, but a port merely REMEMBERED in config does not, so the probe
+        # could answer from port Y while the override still pointed the flash at
+        # port X — board Y's release asset written to board X. avrdude's
+        # part-signature check was the only thing standing in the way, and it
+        # only helps while the two boards have different MCUs; two Unos would
+        # both be `atmega328p -c arduino` and the wrong image would land silently.
+        #
+        # `connected_port` first makes that composition unrepresentable rather
+        # than merely unlikely: whenever there is an identity, it and the target
+        # are the same port by construction. When there is no identity there is
+        # nothing to mismatch, and the operator's named port is used.
+        port_to_use = connected_port or port_override
         method = flash_method(board_to_use)
         if not port_to_use and method not in _PORTLESS_FLASH_METHODS:
             logger.error(

--- a/firestarter/firmware.py
+++ b/firestarter/firmware.py
@@ -814,6 +814,38 @@ class FirmwareManager:
             )
             return False  # Failed to get current version and no intent to install
 
+        # Blind install. When the running firmware could not be identified, an
+        # install is still possible and is in fact the ONLY way off firmware too
+        # old to speak the current protocol: avrdude drives the BOOTLOADER, not
+        # the firmware, so the running image never has to be readable. What is
+        # NOT safe is guessing WHICH image to write — with no identity to go on,
+        # `board_to_use` collapses to the `--board` default, so an unspecified
+        # board would silently resolve the `uno` asset for whatever is attached.
+        # Require the operator to name the board instead of defaulting.
+        # A portless (DFU) board is exempt: it exposes no serial port at all, so
+        # having no identified firmware is its NORMAL state rather than an
+        # ambiguity, and the only way `board_to_use` can name such a board is
+        # for the caller to have named it. There is nothing to confuse it with.
+        identity_optional = method in _PORTLESS_FLASH_METHODS
+        if not current_version and (install_flag or force_install):
+            if not board_explicit and not identity_optional:
+                logger.error(
+                    "Could not identify the programmer, so the firmware image "
+                    "cannot be chosen automatically. Re-run naming the board "
+                    "explicitly to install without identification, e.g. "
+                    "'fw --board uno --install' (see 'fw --help' for the boards "
+                    f"this build supports). Guessing '{board_to_use}' could "
+                    "write the wrong image to the attached board."
+                )
+                return False
+            if not identity_optional:
+                logger.warning(
+                    f"Programmer not identified; installing the {board_to_use} "
+                    "image as explicitly requested. The board is not verified "
+                    "before flashing — avrdude's part-signature check is the "
+                    "only guard."
+                )
+
         is_up_to_date = False
         if current_version and latest_version:
             is_up_to_date = self._compare_versions(current_version, latest_version)

--- a/firestarter/firmware.py
+++ b/firestarter/firmware.py
@@ -586,9 +586,9 @@ class FirmwareManager:
                     logger.info(
                         f"Firmware successfully updated on {port_to_flash} ({time.time() - start_time:.2f}s)"  # noqa: E501
                     )
-                    self.config_manager.set_value(
-                        "port", port_to_flash
-                    )  # Save successful port
+                    # Save the successful port — via remember_port, so a typed
+                    # --port is not promoted into the saved config.
+                    self.config_manager.remember_port(port_to_flash)
                     if (
                         avrdude_path_override is None
                     ):  # Only save if not overridden by user for this run

--- a/firestarter/firmware.py
+++ b/firestarter/firmware.py
@@ -172,6 +172,18 @@ class FirmwareManager:
         """
         Checks the currently installed firmware version on the programmer.
         Returns: (port_name, current_version, board_name) or (None, None, None) on failure.
+
+        ``allow_outdated_firmware=True`` is passed deliberately and is the
+        whole point of this method existing separately from every other
+        connect. Outdated firmware is this path's SUBJECT, not an error
+        condition: the version gate in ``_probe_port`` refuses firmware whose
+        ack predates the CAP-02 identity tail, and applying that refusal here
+        deadlocked the updater — `fw`, `fw --install` and `fw --force` all
+        aborted before the update decision, on firmware whose version was
+        sitting in the very next ack ("FW: <version>:<board>", parsed below).
+        The waiver is scoped to the version refusals only; the shield-revision
+        gate is untouched, and the chip-operation paths still refuse because
+        they never pass this argument.
         """  # noqa: E501
         logger.info("Reading current firmware version...")
         command_dict = {"state": COMMAND_FW_VERSION}
@@ -180,7 +192,10 @@ class FirmwareManager:
         comm = None
         try:
             comm = SerialCommunicator.find_and_connect(
-                command_dict, self.config_manager, preferred_port=preferred_port
+                command_dict,
+                self.config_manager,
+                preferred_port=preferred_port,
+                allow_outdated_firmware=True,
             )
             # find_and_connect gets the initial OK from the programmer.
             # The firmware then executes the fw_version command and sends a second OK with the payload.  # noqa: E501

--- a/firestarter/serial_comm.py
+++ b/firestarter/serial_comm.py
@@ -818,10 +818,17 @@ class SerialCommunicator:
         command_to_send: dict,
         config_manager: ConfigManager,
         fault_inject_outgoing: Optional[Callable[[bytes], bytes]] = None,
+        allow_outdated_firmware: bool = False,
     ) -> Optional["SerialCommunicator"]:
         """
         Attempts to connect to and validate a programmer on a single port.
         This is a helper for find_and_connect.
+
+        ``allow_outdated_firmware`` waives the two firmware-*version* refusals
+        below — the missing-identity refusal and the version floor — and
+        NOTHING else. See the block comment at the version gate for why the
+        firmware-update read path needs it and why no chip operation can ever
+        obtain it.
         """
         communicator = None
         try:
@@ -864,20 +871,53 @@ class SerialCommunicator:
             # board suffix would make int() choke and reject every board).
             identity = communicator.firmware_identity
             version_match = re.match(r"[\d.x]+", identity) if identity else None
+            #
+            # allow_outdated_firmware — the firmware-update read path's waiver.
+            #
+            # The version gate exists so this host never DRIVES firmware whose
+            # wire contract it does not share. Reading the version of firmware
+            # in order to replace it is not driving it: the only caller that
+            # sets this flag is FirmwareManager.check_current_firmware, whose
+            # command is {"state": COMMAND_FW_VERSION} — it engages no bus
+            # line and no VPP/VPE rail, reads one text ack and disconnects.
+            #
+            # Without the waiver the gate is a deadlock: firmware that predates
+            # the CAP-02 identity tail (every stable release, and every beta up
+            # to 3.0.0b1x) sends a bare 2-byte MSG_OK_READY, so `fw`,
+            # `fw --install` and `fw --force` all abort here — the one command
+            # whose job is to replace that firmware is blocked by its
+            # outdatedness, and the refusal text points the operator at
+            # `fw --install`, which hits this same line. The version IS
+            # obtainable: it arrives in the very next ack as
+            # "FW: <version>:<board>", which check_current_firmware already
+            # parses.
+            #
+            # The waiver is an explicit caller opt-in, never inferred from the
+            # command dict, so a chip operation cannot acquire it by accident
+            # or by crafting a command. It does NOT touch the shield-revision
+            # gate below, which still refuses (None is a reject there).
             if version_match is None:
-                raise FirmwareOutdatedError(
-                    "Programmer did not report a firmware version in its "
-                    "operation-setup ack. This host requires firmware that "
-                    "carries the version and hardware revision in that ack. "
-                    "Please upgrade the firmware using 'firestarter fw --install'."  # noqa: E501
+                if not allow_outdated_firmware:
+                    raise FirmwareOutdatedError(
+                        "Programmer did not report a firmware version in its "
+                        "operation-setup ack. This host requires firmware that "
+                        "carries the version and hardware revision in that ack. "
+                        "Please upgrade the firmware using 'firestarter fw --install'."  # noqa: E501
+                    )
+                logger.debug(
+                    f"{port_name}: ack carries no firmware identity "
+                    f"(pre-CAP-02 firmware); proceeding because this is the "
+                    f"firmware-update read path."
                 )
-            # Phase 6 (LFW-05 + LHOST-04): refuse pre-v1.2 firmware. The firmware bumped  # noqa: E501
-            # to major=3 in Phase 9. Set FIRESTARTER_DEV_ALLOW_PRE_V12=1 to bypass when  # noqa: E501
-            # bench-testing a current host against a historical (v2.x) firmware build.  # noqa: E501
-            SerialCommunicator._validate_firmware_version(
-                version_match.group(0),
-                allow_pre_v12=os.environ.get("FIRESTARTER_DEV_ALLOW_PRE_V12") == "1",
-            )
+            elif not allow_outdated_firmware:
+                # Phase 6 (LFW-05 + LHOST-04): refuse pre-v1.2 firmware. The firmware bumped  # noqa: E501
+                # to major=3 in Phase 9. Set FIRESTARTER_DEV_ALLOW_PRE_V12=1 to bypass when  # noqa: E501
+                # bench-testing a current host against a historical (v2.x) firmware build.  # noqa: E501
+                SerialCommunicator._validate_firmware_version(
+                    version_match.group(0),
+                    allow_pre_v12=os.environ.get("FIRESTARTER_DEV_ALLOW_PRE_V12")
+                    == "1",
+                )
 
             # Shield-revision gate — ordered after the version check because
             # firmware old enough to fail that check cannot be trusted to have
@@ -926,9 +966,16 @@ class SerialCommunicator:
         preferred_port: Optional[str] = None,
         baud_rate: int = int(BAUD_RATE),
         fault_inject_outgoing: Optional[Callable[[bytes], bytes]] = None,
+        allow_outdated_firmware: bool = False,
     ) -> "SerialCommunicator":
         """
         Finds a compatible programmer by probing potential serial ports.
+
+        ``allow_outdated_firmware`` is forwarded verbatim to ``_probe_port``
+        and waives ONLY the firmware-version refusals there. It defaults to
+        False, so every caller that does not explicitly ask for it keeps the
+        strict gate; the single production caller that asks is
+        ``FirmwareManager.check_current_firmware``.
 
         ``fault_inject_outgoing`` (Phase 53-04 / XACT-02, dev-only) installs an
         outgoing-frame mutation hook on each probed communicator BEFORE the first
@@ -960,6 +1007,7 @@ class SerialCommunicator:
                     command_to_send,
                     config_manager,
                     fault_inject_outgoing=fault_inject_outgoing,
+                    allow_outdated_firmware=allow_outdated_firmware,
                 )
                 if communicator:
                     if status_update_active:

--- a/firestarter/serial_comm.py
+++ b/firestarter/serial_comm.py
@@ -1087,9 +1087,10 @@ class SerialCommunicator:
             # and not to the firmware.
             raise ProgrammerNotFoundError(
                 f"No compatible programmer answered on {preferred_port}. If a "
-                "board is attached there, its firmware may be too old to speak "
-                "the current protocol (2.x firmware replies 'Bad JSON'). Such a "
-                "board can still be reflashed directly: "
+                "board is attached there, its firmware may predate the current "
+                "command framing, which makes it answer 'Bad JSON' instead of an "
+                "ack — every 2.x release, and 3.0.0 pre-releases before b8. Such "
+                "a board can still be reflashed directly: "
                 f"firestarter --port {preferred_port} fw --board <board> --install"
             )
         raise ProgrammerNotFoundError("No compatible programmer found on any port.")

--- a/firestarter/serial_comm.py
+++ b/firestarter/serial_comm.py
@@ -674,9 +674,46 @@ class SerialCommunicator:
                     )
 
     @staticmethod
-    def _list_potential_ports(preferred_port: Optional[str] = None) -> List[str]:  # noqa: UP006
+    def _remember_working_port(config_manager: ConfigManager, port_name: str) -> None:
+        """Record the port that just answered, for next invocation's convenience.
+
+        A port the operator typed for THIS invocation is NEVER promoted into the
+        saved config. `--port` is documented as applying to one invocation, yet
+        persisting it here silently retargeted every later command at that port —
+        observed live, where `~/.firestarter/config.json` acquired a `port` key
+        from a one-off `--port`. Now that a typed port also RESTRICTS discovery,
+        promoting it would strand later invocations there as well.
+        """
+        config_manager.set_value(
+            "port",
+            port_name,
+            persist=not config_manager.is_transient("port"),
+        )
+
+    @staticmethod
+    def _list_potential_ports(
+        preferred_port: Optional[str] = None,
+        restrict_to_preferred: bool = False,
+    ) -> List[str]:  # noqa: UP006
+        """Candidate ports to probe, most preferred first.
+
+        ``restrict_to_preferred`` makes ``preferred_port`` the ONLY candidate.
+        Set it when the operator named the port on this invocation; leave it
+        False for a port merely remembered from a previous successful run.
+
+        The distinction matters because plain ordering was actively dangerous.
+        When the named port failed to answer — firmware too old to parse the
+        current command framing, or a busy port — probing continued and the
+        caller was handed a DIFFERENT board's identity. `FirmwareManager` then
+        combined that identity with `port_to_use = port_override or
+        connected_port`, i.e. board A's release asset aimed at port B. Only
+        avrdude's part-signature check stood between that and a wrong-firmware
+        flash, and two boards sharing an MCU would not even get that.
+        """
         ports = []
         if preferred_port:
+            if restrict_to_preferred:
+                return [preferred_port]
             ports.append(preferred_port)
 
         system_ports = serial.tools.list_ports.comports()
@@ -929,7 +966,7 @@ class SerialCommunicator:
 
             communicator.programmer_info = msg
             logger.debug(f"Programmer found on {port_name}: {msg}")
-            config_manager.set_value("port", port_name)  # Save successful port
+            SerialCommunicator._remember_working_port(config_manager, port_name)
             return communicator
 
         except HardwareRevisionUnsupportedError:
@@ -967,9 +1004,22 @@ class SerialCommunicator:
         baud_rate: int = int(BAUD_RATE),
         fault_inject_outgoing: Optional[Callable[[bytes], bytes]] = None,
         allow_outdated_firmware: bool = False,
+        restrict_to_port: Optional[bool] = None,
     ) -> "SerialCommunicator":
         """
         Finds a compatible programmer by probing potential serial ports.
+
+        ``restrict_to_port`` decides whether the resolved port is the ONLY
+        candidate. None (the default) infers it from the config's transient
+        mark: `cli()` records a typed ``--port`` with persist=False, and every
+        command reads the port back out of the in-memory config, so that mark is
+        the only surviving evidence that the operator named a port on THIS run
+        rather than the app remembering one from a previous successful run. A
+        typed port is a command and is obeyed exactly; a remembered one yields
+        to discovery, or replugging a board would strand every later invocation.
+        The inference tests `is True` rather than truthiness so a config double
+        answering every call with a Mock falls to the permissive branch instead
+        of silently acquiring a restriction.
 
         ``allow_outdated_firmware`` is forwarded verbatim to ``_probe_port``
         and waives ONLY the firmware-version refusals there. It defaults to
@@ -985,10 +1035,22 @@ class SerialCommunicator:
         sent here is the ONLY corruptible host→fw command frame, so the outgoing
         fault MUST be injected at connection time, not after setup.
         """
+        # Was the port named on THIS invocation, or merely remembered from a
+        # previous successful run? `cli()` records a typed --port with
+        # persist=False, and every command reads it back out of the in-memory
+        # config, so the transient mark is the only surviving evidence of which
+        # one it was. `is True` rather than a truthiness test on purpose: a
+        # config double that answers every call with a Mock must fall to the
+        # permissive branch, not silently acquire a restriction.
+        if restrict_to_port is None:
+            restrict_to_port = config_manager.is_transient("port") is True
+        port_named_this_run = restrict_to_port
         if not preferred_port:
             preferred_port = config_manager.get_value("port")
 
-        potential_ports = cls._list_potential_ports(preferred_port)
+        potential_ports = cls._list_potential_ports(
+            preferred_port, restrict_to_preferred=port_named_this_run
+        )
         if not potential_ports:
             raise ProgrammerNotFoundError("No potential serial ports found.")
 
@@ -1033,6 +1095,20 @@ class SerialCommunicator:
         # If the loop completes without finding a programmer, it's a failure.
         if status_update_active:
             logger.info("Connecting... Failed  ", extra={"status": "end"})
+        if preferred_port and port_named_this_run:
+            # Port was named, so the search was restricted to it. Say which port
+            # failed and name the most likely cause: firmware old enough that it
+            # cannot parse the current command framing answers the handshake with
+            # "Bad JSON" rather than an ack, so it can never be identified — but
+            # it CAN still be reflashed, because avrdude talks to the bootloader
+            # and not to the firmware.
+            raise ProgrammerNotFoundError(
+                f"No compatible programmer answered on {preferred_port}. If a "
+                "board is attached there, its firmware may be too old to speak "
+                "the current protocol (2.x firmware replies 'Bad JSON'). Such a "
+                "board can still be reflashed directly: "
+                f"firestarter --port {preferred_port} fw --board <board> --install"
+            )
         raise ProgrammerNotFoundError("No compatible programmer found on any port.")
 
 

--- a/firestarter/serial_comm.py
+++ b/firestarter/serial_comm.py
@@ -674,23 +674,6 @@ class SerialCommunicator:
                     )
 
     @staticmethod
-    def _remember_working_port(config_manager: ConfigManager, port_name: str) -> None:
-        """Record the port that just answered, for next invocation's convenience.
-
-        A port the operator typed for THIS invocation is NEVER promoted into the
-        saved config. `--port` is documented as applying to one invocation, yet
-        persisting it here silently retargeted every later command at that port —
-        observed live, where `~/.firestarter/config.json` acquired a `port` key
-        from a one-off `--port`. Now that a typed port also RESTRICTS discovery,
-        promoting it would strand later invocations there as well.
-        """
-        config_manager.set_value(
-            "port",
-            port_name,
-            persist=not config_manager.is_transient("port"),
-        )
-
-    @staticmethod
     def _list_potential_ports(
         preferred_port: Optional[str] = None,
         restrict_to_preferred: bool = False,
@@ -966,7 +949,7 @@ class SerialCommunicator:
 
             communicator.programmer_info = msg
             logger.debug(f"Programmer found on {port_name}: {msg}")
-            SerialCommunicator._remember_working_port(config_manager, port_name)
+            config_manager.remember_port(port_name)  # never promotes a typed --port
             return communicator
 
         except HardwareRevisionUnsupportedError:

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -455,7 +455,10 @@ def test_no_blank_check_polarity(snapshot):
 # ``SerialCommunicator._list_potential_ports``, NOT ``serial.tools.list_ports.comports``.
 # ``_list_potential_ports(preferred_port)`` prepends ``preferred_port`` (sourced
 # from ``config_manager.get_value("port")`` in ``find_and_connect``) BEFORE it
-# ever calls ``comports()``. A ``comports``-only patch is therefore defeated by
+# ever calls ``comports()`` — and when the port was named on THIS invocation it
+# returns ``[preferred_port]`` alone, skipping ``comports()`` entirely (the
+# ``restrict_to_preferred`` arm; hence the ``**_kw`` in the stubs below).
+# A ``comports``-only patch is therefore defeated by
 # a saved port in an operator's ``~/.firestarter/config.json`` (or, in CI, by a
 # `` FIRESTARTER_CONFIG_DIR``-scoped config with a "port" key) even though no
 # real board is attached — see
@@ -487,7 +490,7 @@ def test_no_programmer_found_read(monkeypatch):
     monkeypatch.setattr("serial.tools.list_ports.comports", lambda: [])
     monkeypatch.setattr(
         "firestarter.serial_comm.SerialCommunicator._list_potential_ports",
-        lambda preferred_port=None: [],
+        lambda preferred_port=None, **_kw: [],
         raising=True,
     )
     mock_serial = MagicMock()
@@ -520,7 +523,7 @@ def test_no_programmer_found_erase(monkeypatch):
     monkeypatch.setattr("serial.tools.list_ports.comports", lambda: [])
     monkeypatch.setattr(
         "firestarter.serial_comm.SerialCommunicator._list_potential_ports",
-        lambda preferred_port=None: [],
+        lambda preferred_port=None, **_kw: [],
         raising=True,
     )
     mock_serial = MagicMock()

--- a/tests/test_fw_port_targeting_and_blind_install.py
+++ b/tests/test_fw_port_targeting_and_blind_install.py
@@ -1,0 +1,350 @@
+"""
+Project Name: Firestarter
+Copyright (c) 2024 Henrik Olsson
+
+Permission is hereby granted under MIT license.
+
+Regression suite for three targeting defects found on the bench while exercising
+every firmware-update path (debug session
+`.planning/debug/fw-update-blocked-release-fw.md`, "SUPERSEDING FINDINGS").
+They are independent of the CAP-02 waiver pinned in
+`test_fw_update_path_gate.py`, and each was more dangerous than that one.
+
+A — `--port` ORDERED the probe list instead of RESTRICTING it. When the named
+port failed to answer, probing silently continued to the next port and the
+caller was handed a different board's identity. `FirmwareManager` then combined
+that identity with `port_to_use = port_override or connected_port`, so board A's
+release asset was aimed at port B. Measured on the bench: with stable 2.0.6 on
+/dev/ttyACM1 (which answers the handshake with `ERROR: Bad JSON`) and a
+uno328pb on /dev/ttyUSB0, `fw --port /dev/ttyACM1 --install` downloaded
+`firestarter_uno328pb.hex` and ran
+`avrdude -p atmega328pb -c urclock -P /dev/ttyACM1`. Only avrdude's
+part-signature check (0x1e950f is not m328pb) prevented a wrong-firmware flash;
+two boards sharing an MCU and programmer would not get even that.
+
+B — firmware too old to parse the current command framing can never be
+identified, so it could never be updated. avrdude drives the BOOTLOADER, not the
+firmware, so an install does not need the running image to be readable — but it
+does need to know WHICH image to write, and with no identity `board_to_use`
+collapses to the `--board` default. A blind install is therefore allowed only
+when the operator names the board.
+
+C — `set_value(..., persist=False)` was not honoured across a later persisted
+write of an UNRELATED key. `_save_config` dumped the whole in-memory dict, so
+`firmware.py` caching `avrdude-path` after a successful flash wrote the
+one-shot `--port` to disk permanently. Observed live: `~/.firestarter/config.json`
+gained `"port": "/dev/ttyUSB0"` from a `--port` that is documented as applying
+to a single invocation, silently retargeting every later command.
+"""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from firestarter.config import ConfigManager
+from firestarter.constants import FLAG_FORCE
+from firestarter.exceptions import ProgrammerNotFoundError
+from firestarter.firmware import FirmwareManager
+from firestarter.serial_comm import SerialCommunicator
+
+
+def _fake_comports(*devices):
+    """Build comports() entries that _list_potential_ports would accept."""
+    entries = []
+    for dev in devices:
+        entry = MagicMock()
+        entry.device = dev
+        entry.manufacturer = "Arduino"
+        entry.description = "USB Serial"
+        entries.append(entry)
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# A — a named port restricts the search
+# ---------------------------------------------------------------------------
+
+
+class TestNamedPortRestrictsTheSearch:
+    def test_named_port_is_the_only_candidate(self):
+        """The defect: other ports were appended after the named one."""
+        with patch(
+            "serial.tools.list_ports.comports",
+            return_value=_fake_comports("/dev/ttyACM0", "/dev/ttyACM1", "/dev/ttyUSB0"),
+        ):
+            ports = SerialCommunicator._list_potential_ports(
+                "/dev/ttyACM1", restrict_to_preferred=True
+            )
+        assert ports == ["/dev/ttyACM1"], (
+            "a named port must RESTRICT the search; listing other ports lets a "
+            "different board answer for the one that was asked about"
+        )
+
+    def test_remembered_port_is_preferred_but_not_exclusive(self):
+        """A port merely remembered from a previous run must yield to discovery.
+
+        Otherwise replugging a board strands every later invocation on a port
+        that no longer exists — the restriction above must not cost that.
+        """
+        with patch(
+            "serial.tools.list_ports.comports",
+            return_value=_fake_comports("/dev/ttyACM0", "/dev/ttyUSB0"),
+        ):
+            ports = SerialCommunicator._list_potential_ports(
+                "/dev/ttyUSB0", restrict_to_preferred=False
+            )
+        assert ports[0] == "/dev/ttyUSB0", "the remembered port must still be first"
+        assert "/dev/ttyACM0" in ports, "discovery must still reach the other ports"
+
+    def test_no_named_port_still_enumerates(self):
+        """Non-regression: discovery is unchanged when no port is named."""
+        with patch(
+            "serial.tools.list_ports.comports",
+            return_value=_fake_comports("/dev/ttyACM0", "/dev/ttyUSB0"),
+        ):
+            ports = SerialCommunicator._list_potential_ports(None)
+        assert ports == ["/dev/ttyACM0", "/dev/ttyUSB0"]
+
+    def test_mute_named_port_never_probes_a_second_port(self, monkeypatch):
+        """A port that does not answer must NOT fall through to another board."""
+        probed = []
+
+        def mock_probe(port_name, *_a, **_k):
+            probed.append(port_name)
+            return None  # "responded but not with OK" — e.g. Bad JSON on 2.x
+
+        monkeypatch.setattr(SerialCommunicator, "_probe_port", mock_probe)
+        monkeypatch.setattr(
+            "serial.tools.list_ports.comports",
+            lambda: _fake_comports("/dev/ttyACM1", "/dev/ttyUSB0"),
+        )
+        cfg = MagicMock()
+        cfg.get_value.return_value = None
+        # Production marks a typed --port transient; a bare Mock would answer
+        # every call truthily, so state the mechanism explicitly.
+        cfg.is_transient.return_value = True
+
+        with pytest.raises(ProgrammerNotFoundError) as exc:
+            SerialCommunicator.find_and_connect(
+                {"state": 13}, cfg, preferred_port="/dev/ttyACM1"
+            )
+
+        assert probed == ["/dev/ttyACM1"], (
+            f"probing continued past the named port: {probed}. That is how a "
+            f"different board's identity reached the caller."
+        )
+        message = str(exc.value)
+        assert "/dev/ttyACM1" in message, "the failure must name the port asked for"
+        assert "--board" in message, (
+            "the message must point at the one escape hatch for unidentifiable "
+            "firmware, otherwise it is a dead end"
+        )
+
+    def test_remembered_port_still_falls_through_to_other_ports(self, monkeypatch):
+        """The permissive half of the rule, end to end through find_and_connect."""
+        probed = []
+
+        def mock_probe(port_name, *_a, **_k):
+            probed.append(port_name)
+            return None
+
+        monkeypatch.setattr(SerialCommunicator, "_probe_port", mock_probe)
+        monkeypatch.setattr(
+            "serial.tools.list_ports.comports",
+            lambda: _fake_comports("/dev/ttyACM1", "/dev/ttyUSB0"),
+        )
+        cfg = MagicMock()
+        cfg.get_value.return_value = "/dev/ttyUSB0"
+        cfg.is_transient.return_value = False  # remembered, not typed this run
+
+        with pytest.raises(ProgrammerNotFoundError) as exc:
+            SerialCommunicator.find_and_connect({"state": 13}, cfg)
+
+        assert probed == ["/dev/ttyUSB0", "/dev/ttyACM1"], (
+            f"a remembered port must not strand discovery, got {probed}"
+        )
+        assert "on any port" in str(exc.value), (
+            "the port-specific message belongs to the restricted path only"
+        )
+
+    def test_typed_port_is_not_promoted_into_the_saved_config(self, monkeypatch):
+        """A successful probe must not persist a port meant for one invocation."""
+        saved = []
+        cfg = MagicMock()
+        cfg.is_transient.return_value = True
+        cfg.set_value.side_effect = lambda k, v, persist=True: saved.append(
+            (k, v, persist)
+        )
+
+        SerialCommunicator._remember_working_port(cfg, "/dev/ttyACM1")
+
+        assert saved == [("port", "/dev/ttyACM1", False)], (
+            "a typed --port was written to disk, which silently retargets and "
+            "now also restricts every later invocation"
+        )
+
+    def test_discovered_port_is_still_remembered(self, monkeypatch):
+        """Non-regression: the remember-the-working-port convenience survives."""
+        saved = []
+        cfg = MagicMock()
+        cfg.is_transient.return_value = False
+        cfg.set_value.side_effect = lambda k, v, persist=True: saved.append(
+            (k, v, persist)
+        )
+
+        SerialCommunicator._remember_working_port(cfg, "/dev/ttyACM1")
+
+        assert saved == [("port", "/dev/ttyACM1", True)]
+
+
+# ---------------------------------------------------------------------------
+# B — blind install, gated on an explicit --board
+# ---------------------------------------------------------------------------
+
+
+def _manager_that_cannot_identify(monkeypatch):
+    """A FirmwareManager whose identification step yields nothing."""
+    fm = FirmwareManager(config_manager=MagicMock())
+    monkeypatch.setattr(fm, "check_current_firmware", lambda **_kw: (None, None, None))
+    monkeypatch.setattr(
+        fm,
+        "fetch_release_info",
+        lambda channel="stable", version=None, board="uno": (
+            "3.0.0b19",
+            f"https://example.invalid/{board}.hex",
+        ),
+    )
+    return fm
+
+
+class TestBlindInstallRequiresExplicitBoard:
+    @pytest.mark.parametrize(
+        ("install_flag", "flags", "label"),
+        [(True, 0, "--install"), (False, FLAG_FORCE, "--force")],
+    )
+    def test_refused_without_an_explicit_board(
+        self, monkeypatch, caplog, install_flag, flags, label
+    ):
+        """Guessing the board could write the wrong image — refuse instead."""
+        fm = _manager_that_cannot_identify(monkeypatch)
+        monkeypatch.setattr(
+            fm,
+            "_download_firmware_file",
+            lambda url: pytest.fail(f"{label} must not download without --board"),
+        )
+        monkeypatch.setattr(
+            fm,
+            "_install_firmware",
+            lambda **kw: pytest.fail(f"{label} must not flash without --board"),
+        )
+
+        with caplog.at_level("ERROR"):
+            ok = fm.manage_firmware_update(
+                install_flag=install_flag,
+                flags=flags,
+                port_override="/dev/ttyACM1",
+                board_explicit=False,
+            )
+
+        assert ok is False
+        assert "cannot be chosen automatically" in caplog.text
+
+    def test_allowed_with_an_explicit_board(self, monkeypatch):
+        """Named board + unreadable firmware = the only way off 2.x firmware."""
+        fm = _manager_that_cannot_identify(monkeypatch)
+        installed = {}
+        monkeypatch.setattr(
+            fm, "_download_firmware_file", lambda url: "/tmp/fake_uno.hex"
+        )
+        monkeypatch.setattr(
+            fm,
+            "_install_firmware",
+            lambda **kw: installed.update(kw) or True,
+        )
+
+        ok = fm.manage_firmware_update(
+            install_flag=True,
+            port_override="/dev/ttyACM1",
+            board_override="leonardo",
+            board_explicit=True,
+        )
+
+        assert ok is True
+        assert installed["board"] == "leonardo", (
+            "the operator's explicit board must select the image, since there is "
+            "no detected board to take it from"
+        )
+        assert installed["target_port"] == "/dev/ttyACM1"
+
+    def test_bare_check_still_refuses_without_install_intent(self, monkeypatch):
+        """Non-regression: no install intent + no version is still an error."""
+        fm = _manager_that_cannot_identify(monkeypatch)
+        monkeypatch.setattr(
+            fm,
+            "_install_firmware",
+            lambda **kw: pytest.fail("a bare check must never flash"),
+        )
+        ok = fm.manage_firmware_update(
+            port_override="/dev/ttyACM1", board_explicit=True
+        )
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# C — transient config values must not reach the disk
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_config_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("FIRESTARTER_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr("firestarter.config.HOME_PATH", str(tmp_path))
+    ConfigManager._instances.clear()
+    ConfigManager._initialized_configs.clear()
+    yield str(tmp_path)
+    ConfigManager._instances.clear()
+    ConfigManager._initialized_configs.clear()
+
+
+class TestTransientValuesNeverPersist:
+    def test_unrelated_persisted_write_does_not_leak_the_transient_port(
+        self, tmp_config_dir
+    ):
+        """The live defect: caching avrdude-path wrote the one-shot --port."""
+        cm = ConfigManager(config_filename="t_transient_leak.json")
+        cm.set_value("port", "/dev/ttyUSB0", persist=False)
+        cm.set_value("avrdude-path", "/usr/bin/avrdude")  # persist=True default
+
+        with open(os.path.join(tmp_config_dir, "t_transient_leak.json")) as f:
+            on_disk = json.load(f)
+
+        assert on_disk == {"avrdude-path": "/usr/bin/avrdude"}, (
+            "a --port documented as applying to one invocation was written to "
+            "disk, silently retargeting every later command"
+        )
+        assert cm.get_value("port") == "/dev/ttyUSB0", (
+            "the value must still apply to THIS invocation"
+        )
+
+    def test_explicit_persisted_write_promotes_the_key(self, tmp_config_dir):
+        """`config port X` after a `--port Y` must still be saved."""
+        cm = ConfigManager(config_filename="t_transient_promote.json")
+        cm.set_value("port", "/dev/ttyACM0", persist=False)
+        cm.set_value("port", "/dev/ttyACM1", persist=True)
+
+        with open(os.path.join(tmp_config_dir, "t_transient_promote.json")) as f:
+            on_disk = json.load(f)
+        assert on_disk["port"] == "/dev/ttyACM1"
+
+    def test_removing_a_transient_key_clears_its_transient_mark(self, tmp_config_dir):
+        """A key cleared then re-set persisted must not stay suppressed."""
+        cm = ConfigManager(config_filename="t_transient_cleared.json")
+        cm.set_value("port", "/dev/ttyACM0", persist=False)
+        cm.set_value("port", None, persist=False)
+        cm.set_value("port", "/dev/ttyACM1", persist=True)
+
+        with open(os.path.join(tmp_config_dir, "t_transient_cleared.json")) as f:
+            on_disk = json.load(f)
+        assert on_disk["port"] == "/dev/ttyACM1"

--- a/tests/test_fw_port_targeting_and_blind_install.py
+++ b/tests/test_fw_port_targeting_and_blind_install.py
@@ -313,6 +313,49 @@ class TestBlindInstallRequiresExplicitBoard:
         )
         assert installed["target_port"] == "/dev/ttyACM1"
 
+    def test_identity_and_target_always_come_from_the_same_port(self, monkeypatch):
+        """The composition at the heart of defect A must be unrepresentable.
+
+        Restricting the probe closed the TYPED-port path, but a port merely
+        REMEMBERED in config does not restrict, so the probe can still answer
+        from a different port than the override names. With
+        `port_to_use = port_override or connected_port` that produced board Y's
+        asset aimed at port X — and avrdude's part-signature check is the only
+        guard, which helps only while the two boards have different MCUs. Two
+        Unos are both `atmega328p -c arduino`, so the wrong image would land
+        silently. Whenever there IS an identity, it and the target must be the
+        same port by construction.
+        """
+        installed = {}
+        fm = FirmwareManager(config_manager=MagicMock())
+        # Probe answered on ttyUSB0 (a fall-through) while the override names ttyACM1.
+        monkeypatch.setattr(
+            fm,
+            "check_current_firmware",
+            lambda **_kw: ("/dev/ttyUSB0", "3.0.0b11", "uno328pb"),
+        )
+        monkeypatch.setattr(
+            fm,
+            "fetch_release_info",
+            lambda channel="stable", version=None, board="uno": (
+                "3.0.0b19",
+                f"https://example.invalid/{board}.hex",
+            ),
+        )
+        monkeypatch.setattr(fm, "_download_firmware_file", lambda url: "/tmp/fake.hex")
+        monkeypatch.setattr(
+            fm, "_install_firmware", lambda **kw: installed.update(kw) or True
+        )
+
+        fm.manage_firmware_update(install_flag=True, port_override="/dev/ttyACM1")
+
+        assert installed["target_port"] == "/dev/ttyUSB0", (
+            "the flash was aimed at the override port while the board identity "
+            "came from another port — board A's image written to board B, with "
+            "only avrdude's signature check in the way"
+        )
+        assert installed["board"] == "uno328pb"
+
     def test_bare_check_still_refuses_without_install_intent(self, monkeypatch):
         """Non-regression: no install intent + no version is still an error."""
         fm = _manager_that_cannot_identify(monkeypatch)

--- a/tests/test_fw_port_targeting_and_blind_install.py
+++ b/tests/test_fw_port_targeting_and_blind_install.py
@@ -29,6 +29,21 @@ does need to know WHICH image to write, and with no identity `board_to_use`
 collapses to the `--board` default. A blind install is therefore allowed only
 when the operator names the board.
 
+Measured framing boundary (bench, 2026-08-19): stable `2.0.6` AND pre-release
+`3.0.0b4` both answer the handshake with `ERROR: Bad JSON`, so the probe returns
+None and no identity is obtainable. `3.0.0b11` does NOT — it acks, just without
+the CAP-02 identity tail, which is the *waiver* case in
+`test_fw_update_path_gate.py` rather than this one. The boundary is the COBS
+pivot at firmware b8, so the two defects are genuinely distinct populations:
+pre-b8 firmware needs the blind install below, b8..b18 needs the waiver.
+
+The blind path is proven on all three flash methods on real hardware: `arduino`
+(uno, 2.0.6 → b19), `avr109` (leonardo, 2.0.6 → b19 — this one also exercises
+Avrdude._trigger_reset's 1200-baud touch, which only runs for atmega32u4), and
+`urclock` (uno328pb, from b4 — release lookup rate-limited mid-test, so that
+board was restored with avrdude directly and the urclock blind leg is proven only
+as far as the download boundary).
+
 C — `set_value(..., persist=False)` was not honoured across a later persisted
 write of an UNRELATED key. `_save_config` dumped the whole in-memory dict, so
 `firmware.py` caching `avrdude-path` after a successful flash wrote the

--- a/tests/test_fw_port_targeting_and_blind_install.py
+++ b/tests/test_fw_port_targeting_and_blind_install.py
@@ -39,6 +39,7 @@ to a single invocation, silently retargeting every later command.
 
 import json
 import os
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -169,34 +170,53 @@ class TestNamedPortRestrictsTheSearch:
             "the port-specific message belongs to the restricted path only"
         )
 
-    def test_typed_port_is_not_promoted_into_the_saved_config(self, monkeypatch):
-        """A successful probe must not persist a port meant for one invocation."""
-        saved = []
-        cfg = MagicMock()
-        cfg.is_transient.return_value = True
-        cfg.set_value.side_effect = lambda k, v, persist=True: saved.append(
-            (k, v, persist)
-        )
+    def test_typed_port_is_not_promoted_into_the_saved_config(self, tmp_config_dir):
+        """A working port must not persist a port meant for one invocation."""
+        cm = ConfigManager(config_filename="t_remember_typed.json")
+        cm.set_value("port", "/dev/ttyACM1", persist=False)  # what cli() does
 
-        SerialCommunicator._remember_working_port(cfg, "/dev/ttyACM1")
+        cm.remember_port("/dev/ttyACM1")
 
-        assert saved == [("port", "/dev/ttyACM1", False)], (
+        cfg_path = os.path.join(tmp_config_dir, "t_remember_typed.json")
+        on_disk = {}
+        if os.path.exists(cfg_path):
+            with open(cfg_path) as f:
+                on_disk = json.load(f)
+        assert "port" not in on_disk, (
             "a typed --port was written to disk, which silently retargets and "
             "now also restricts every later invocation"
         )
+        assert cm.get_value("port") == "/dev/ttyACM1", "still applies to THIS run"
 
-    def test_discovered_port_is_still_remembered(self, monkeypatch):
+    def test_discovered_port_is_still_remembered(self, tmp_config_dir):
         """Non-regression: the remember-the-working-port convenience survives."""
-        saved = []
-        cfg = MagicMock()
-        cfg.is_transient.return_value = False
-        cfg.set_value.side_effect = lambda k, v, persist=True: saved.append(
-            (k, v, persist)
+        cm = ConfigManager(config_filename="t_remember_found.json")
+
+        cm.remember_port("/dev/ttyACM1")
+
+        with open(os.path.join(tmp_config_dir, "t_remember_found.json")) as f:
+            assert json.load(f)["port"] == "/dev/ttyACM1"
+
+    def test_remember_port_is_the_only_writer_of_the_saved_port(self):
+        """Source tripwire: the rule lived in two call sites and drifted.
+
+        `serial_comm` (successful probe) and `firmware` (successful flash) each
+        persisted the port independently. Fixing only the first left the leak
+        live — the flash path still promoted a typed `--port`. Any new direct
+        write of the key would reintroduce it, so pin `remember_port` as the sole
+        writer.
+        """
+        pkg = Path(__file__).resolve().parents[1] / "firestarter"
+        offenders = sorted(
+            p.name
+            for p in pkg.rglob("*.py")
+            if 'set_value("port"' in p.read_text() and p.name != "cli_handlers.py"
         )
-
-        SerialCommunicator._remember_working_port(cfg, "/dev/ttyACM1")
-
-        assert saved == [("port", "/dev/ttyACM1", True)]
+        assert offenders == ["config.py"], (
+            f"{offenders} write the saved port directly; route them through "
+            f"ConfigManager.remember_port so the typed-vs-remembered rule "
+            f"cannot drift between call sites again"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fw_update_path_gate.py
+++ b/tests/test_fw_update_path_gate.py
@@ -156,7 +156,9 @@ class TestWaiverPlumbing:
             SerialCommunicator, "_probe_port", staticmethod(lambda *a, **k: spy(**k))
         )
         monkeypatch.setattr(
-            SerialCommunicator, "_list_potential_ports", staticmethod(lambda p: ["/x"])
+            SerialCommunicator,
+            "_list_potential_ports",
+            staticmethod(lambda p, **_kw: ["/x"]),
         )
         SerialCommunicator.find_and_connect({"state": 1}, MagicMock())
         assert seen["allow_outdated_firmware"] is False
@@ -172,7 +174,9 @@ class TestWaiverPlumbing:
             SerialCommunicator, "_probe_port", staticmethod(lambda *a, **k: spy(**k))
         )
         monkeypatch.setattr(
-            SerialCommunicator, "_list_potential_ports", staticmethod(lambda p: ["/x"])
+            SerialCommunicator,
+            "_list_potential_ports",
+            staticmethod(lambda p, **_kw: ["/x"]),
         )
         SerialCommunicator.find_and_connect(
             {"state": 1}, MagicMock(), allow_outdated_firmware=True
@@ -278,7 +282,7 @@ class TestUpdateDecisionReachedOnPreCap02Firmware:
         """
         monkeypatch.setattr(
             "firestarter.serial_comm.SerialCommunicator._list_potential_ports",
-            staticmethod(lambda p: ["/dev/null"]),
+            staticmethod(lambda p, **_kw: ["/dev/null"]),
         )
         fm = FirmwareManager(config_manager=MagicMock())
         monkeypatch.setattr(

--- a/tests/test_fw_update_path_gate.py
+++ b/tests/test_fw_update_path_gate.py
@@ -1,0 +1,394 @@
+"""
+Project Name: Firestarter
+Copyright (c) 2024 Henrik Olsson
+
+Permission is hereby granted under MIT license.
+
+Regression suite for the "a pre-release app cannot update pre-CAP-02 firmware"
+deadlock (debug session `.planning/debug/fw-update-blocked-release-fw.md`).
+
+Two independent defects are pinned here.
+
+D1 — the firmware-update read path was blocked by the version gate it exists
+to resolve. `SerialCommunicator._probe_port` refuses any ack that carries no
+CAP-02 identity tail, and `FirmwareManager.manage_firmware_update` calls
+`check_current_firmware` as its FIRST statement, which re-raises
+`FirmwareOutdatedError`. Measured on the bench: `fw`, `fw --install`,
+`fw --force`, `fw --install --pre` and `fw --firmware-version 3.0.0b19` all
+aborted on two Uno-class boards running 3.0.0b11 firmware (ack body
+`01 02 00 41` — no identity tail) with ZERO calls to the download or install
+paths. Meanwhile the version was sitting in the very next ack as
+`OK: FW: 3.0.0b11:uno`. The fix is an explicit, caller-declared
+`allow_outdated_firmware` waiver, scoped to the version refusals only.
+
+The pair of tests per case is the point: every waiver test has a twin that
+proves the strict path is UNCHANGED without the flag. The waiver must never
+become reachable from a chip operation, so a source-level tripwire below pins
+the set of production call sites that pass it.
+
+D2 — `_maybe_auto_route_to_pre` gated the beta-app pre-channel auto-route on
+`--install`, so on a pre-release app bare `fw` compared against the newest
+STABLE firmware (2.0.6) and reported "already up to date", and `fw --force`
+resolved the stable asset — a DOWNGRADE to firmware this host cannot speak to.
+"""
+
+import contextlib
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from firestarter.exceptions import FirmwareOutdatedError
+from firestarter.firmware import FirmwareManager
+from firestarter.serial_comm import SerialCommunicator
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _probe_with_identity(identity):
+    """Patch out serial I/O and pin the CAP-02 firmware identity string.
+
+    Same shape as tests/test_fwguard.py's helper — deliberately duplicated
+    rather than imported so this file states its own preconditions.
+    """
+    with (
+        patch.object(SerialCommunicator, "expect_ack", return_value=(True, "Ready")),
+        patch.object(SerialCommunicator, "send_json_command", return_value=42),
+        patch.object(SerialCommunicator, "consume_remaining_input", return_value=None),
+        patch.object(SerialCommunicator, "disconnect", return_value=None),
+        patch.object(SerialCommunicator, "firmware_identity", identity),
+        patch.object(SerialCommunicator, "hw_revision", None),
+        patch.object(SerialCommunicator, "port_name", "/dev/null", create=True),
+        patch.object(SerialCommunicator, "__init__", lambda self, port, **k: None),
+    ):
+        yield
+
+
+def _probe(**kwargs):
+    """Run _probe_port with a plain non-gated command (no bus-config)."""
+    return SerialCommunicator._probe_port(
+        port_name="/dev/null",
+        baud_rate=250000,
+        command_to_send={"state": 1},
+        config_manager=MagicMock(),
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# D1 — the waiver, and its twin proving the strict path is unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestOutdatedFirmwareWaiverScope:
+    @pytest.fixture(autouse=True)
+    def _clear_escape_hatch(self, monkeypatch):
+        monkeypatch.delenv("FIRESTARTER_DEV_ALLOW_PRE_V12", raising=False)
+
+    def test_absent_identity_is_tolerated_on_the_update_path(self):
+        """D1 core: pre-CAP-02 ack must NOT abort the firmware-update read."""
+        with _probe_with_identity(None):
+            comm = _probe(allow_outdated_firmware=True)
+        assert comm is not None, (
+            "the firmware-update read path must reach a usable connection on "
+            "firmware whose ack carries no identity tail — that firmware is "
+            "the subject of the update, not an error condition"
+        )
+
+    def test_absent_identity_still_refuses_without_the_waiver(self):
+        """Twin: the chip-operation path must be byte-for-byte as strict."""
+        with _probe_with_identity(None):
+            with pytest.raises(FirmwareOutdatedError, match="did not report"):
+                _probe()
+
+    def test_absent_identity_still_refuses_when_waiver_explicitly_false(self):
+        """Twin, explicit form — no default-argument ambiguity."""
+        with _probe_with_identity(None):
+            with pytest.raises(FirmwareOutdatedError, match="did not report"):
+                _probe(allow_outdated_firmware=False)
+
+    def test_pre_v3_identity_is_tolerated_on_the_update_path(self):
+        """A 2.x board must be readable so it can be upgraded off 2.x."""
+        with _probe_with_identity("2.0.11:uno"):
+            comm = _probe(allow_outdated_firmware=True)
+        assert comm is not None
+
+    def test_pre_v3_identity_still_refuses_without_the_waiver(self):
+        """Twin: LFW-05 / LHOST-04 refusal is untouched for chip operations."""
+        with _probe_with_identity("2.0.11:uno"):
+            with pytest.raises(FirmwareOutdatedError, match="pre-v1.2"):
+                _probe()
+
+    def test_waiver_does_not_touch_the_shield_revision_gate(self):
+        """The waiver is scoped to VERSION refusals only.
+
+        A command that routes VPP to bus line 11 on firmware that reports no
+        revision must still be refused, waiver or not — that refusal is a
+        chip-damage guard, not a version policy.
+        """
+        from firestarter.exceptions import HardwareRevisionUnsupportedError
+
+        with _probe_with_identity(None):
+            with pytest.raises(HardwareRevisionUnsupportedError):
+                SerialCommunicator._probe_port(
+                    port_name="/dev/null",
+                    baud_rate=250000,
+                    command_to_send={"bus-config": {"vpp-pin": 11}},
+                    config_manager=MagicMock(),
+                    allow_outdated_firmware=True,
+                )
+
+
+class TestWaiverPlumbing:
+    def test_find_and_connect_defaults_to_the_strict_gate(self, monkeypatch):
+        """Every caller that says nothing keeps the gate."""
+        seen = {}
+
+        def spy(**kwargs):
+            seen.update(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr(
+            SerialCommunicator, "_probe_port", staticmethod(lambda *a, **k: spy(**k))
+        )
+        monkeypatch.setattr(
+            SerialCommunicator, "_list_potential_ports", staticmethod(lambda p: ["/x"])
+        )
+        SerialCommunicator.find_and_connect({"state": 1}, MagicMock())
+        assert seen["allow_outdated_firmware"] is False
+
+    def test_find_and_connect_forwards_the_waiver(self, monkeypatch):
+        seen = {}
+
+        def spy(**kwargs):
+            seen.update(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr(
+            SerialCommunicator, "_probe_port", staticmethod(lambda *a, **k: spy(**k))
+        )
+        monkeypatch.setattr(
+            SerialCommunicator, "_list_potential_ports", staticmethod(lambda p: ["/x"])
+        )
+        SerialCommunicator.find_and_connect(
+            {"state": 1}, MagicMock(), allow_outdated_firmware=True
+        )
+        assert seen["allow_outdated_firmware"] is True
+
+    def test_check_current_firmware_requests_the_waiver(self, monkeypatch):
+        """The updater is the one production caller that opts in."""
+        seen = {}
+
+        def mock_connect(*_args, **kwargs):
+            seen.update(kwargs)
+            comm = MagicMock()
+            comm.port_name = "/dev/ttyACM1"
+            comm.expect_ack.return_value = (True, "FW: 3.0.0b11:uno")
+            return comm
+
+        monkeypatch.setattr(
+            "firestarter.serial_comm.SerialCommunicator.find_and_connect",
+            mock_connect,
+        )
+        fm = FirmwareManager(config_manager=MagicMock())
+        assert fm.check_current_firmware() == ("/dev/ttyACM1", "3.0.0b11", "uno")
+        assert seen.get("allow_outdated_firmware") is True
+
+    def test_only_the_updater_passes_the_waiver(self):
+        """Source-level tripwire: the waiver must not spread.
+
+        `allow_outdated_firmware=True` may appear in exactly one production
+        module — firmware.py, in check_current_firmware. serial_comm.py owns
+        the parameter itself. Any other production module gaining it means a
+        chip-operation path has acquired the relaxation, which is the whole
+        thing this fix must not do.
+        """
+        pkg = Path(__file__).resolve().parents[1] / "firestarter"
+        offenders = sorted(
+            p.name
+            for p in pkg.rglob("*.py")
+            if "allow_outdated_firmware=True" in p.read_text()
+            and p.name not in ("serial_comm.py", "firmware.py")
+        )
+        assert offenders == [], (
+            f"the outdated-firmware waiver leaked into {offenders}; it is only "
+            f"legitimate on the firmware-update read path"
+        )
+
+
+class TestUpdateDecisionReachedOnPreCap02Firmware:
+    """The end-to-end regression: the update decision must be REACHED."""
+
+    def test_manage_firmware_update_reaches_the_download_boundary(self, monkeypatch):
+        """No identity in the ack, version from the legacy text ack, then install.
+
+        Drives the real check_current_firmware against a fake connection that
+        reproduces the bench boards exactly: first ack "Ready" with
+        firmware_identity None, second ack "FW: 3.0.0b11:uno".
+        """
+        downloads = []
+
+        def mock_connect(*_args, **_kwargs):
+            comm = MagicMock()
+            comm.port_name = "/dev/ttyACM1"
+            comm.firmware_identity = None
+            comm.expect_ack.return_value = (True, "FW: 3.0.0b11:uno")
+            return comm
+
+        monkeypatch.setattr(
+            "firestarter.serial_comm.SerialCommunicator.find_and_connect",
+            mock_connect,
+        )
+        fm = FirmwareManager(config_manager=MagicMock())
+        monkeypatch.setattr(
+            fm,
+            "fetch_release_info",
+            lambda channel="stable", version=None, board="uno": (
+                "3.0.0b19",
+                f"https://example.invalid/{board}.hex",
+            ),
+        )
+        monkeypatch.setattr(
+            fm,
+            "_download_firmware_file",
+            lambda url: downloads.append(url) or None,
+        )
+        monkeypatch.setattr(
+            fm,
+            "_install_firmware",
+            lambda **kw: pytest.fail("must stop at the download boundary"),
+        )
+
+        fm.manage_firmware_update(install_flag=True, channel="pre")
+
+        assert downloads == ["https://example.invalid/uno.hex"], (
+            "the update decision was not reached — this is the original "
+            "deadlock: FirmwareOutdatedError raised before any release lookup"
+        )
+
+    def test_the_deadlock_shape_is_gone(self, monkeypatch):
+        """manage_firmware_update must not propagate the gate's refusal.
+
+        Pins the causal chain rather than the message: an ack with no identity
+        must no longer produce FirmwareOutdatedError out of the update path.
+        """
+        monkeypatch.setattr(
+            "firestarter.serial_comm.SerialCommunicator._list_potential_ports",
+            staticmethod(lambda p: ["/dev/null"]),
+        )
+        fm = FirmwareManager(config_manager=MagicMock())
+        monkeypatch.setattr(
+            fm, "fetch_release_info", lambda **kw: ("3.0.0b19", "https://x.invalid/u")
+        )
+        monkeypatch.setattr(fm, "_download_firmware_file", lambda url: None)
+
+        with _probe_with_identity(None):
+            with patch.object(
+                SerialCommunicator,
+                "expect_ack",
+                return_value=(True, "FW: 3.0.0b11:uno"),
+            ):
+                # Not raising is the assertion. Return value is False because
+                # the (stubbed) download fails, which is a later stage.
+                fm.manage_firmware_update(install_flag=True, port_override="/dev/null")
+
+
+# ---------------------------------------------------------------------------
+# D2 — channel resolution on a pre-release app
+# ---------------------------------------------------------------------------
+
+
+class TestChannelAutoRouteIsNotGatedOnInstall:
+    """A pre-release app must compare against, and install from, its own channel."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate_version(self, monkeypatch):
+        import firestarter as _pkg
+
+        monkeypatch.setattr(_pkg, "__version__", _pkg.__version__)
+
+    def _args(self, **over):
+        from types import SimpleNamespace
+
+        base = dict(install=False, pre=False, firmware_version=None, stable=False)
+        base.update(over)
+        return SimpleNamespace(**base)
+
+    def test_bare_fw_auto_routes_on_a_pre_release_app(self, monkeypatch):
+        """The status query must not measure a beta app against stable firmware."""
+        import firestarter as _pkg
+        from firestarter.cli_handlers import _maybe_auto_route_to_pre
+
+        monkeypatch.setattr(_pkg, "__version__", "3.0.0b21")
+        args = self._args(install=False)
+        _maybe_auto_route_to_pre(args)
+        assert args.pre is True, (
+            "bare `fw` on a pre-release app resolved the stable channel, so it "
+            "compared 3.0.0b17 against 2.0.6 and reported 'already up to date'"
+        )
+
+    def test_force_without_install_auto_routes(self, monkeypatch):
+        """`fw --force` must not resolve a stable DOWNGRADE asset."""
+        import firestarter as _pkg
+        from firestarter.cli_handlers import _maybe_auto_route_to_pre
+
+        monkeypatch.setattr(_pkg, "__version__", "3.0.0b21")
+        args = self._args(install=False)
+        _maybe_auto_route_to_pre(args)
+        assert args.pre is True
+
+    def test_install_still_auto_routes(self, monkeypatch):
+        """Non-regression on the original D-21/D-22 behaviour."""
+        import firestarter as _pkg
+        from firestarter.cli_handlers import _maybe_auto_route_to_pre
+
+        monkeypatch.setattr(_pkg, "__version__", "3.0.0b21")
+        args = self._args(install=True)
+        _maybe_auto_route_to_pre(args)
+        assert args.pre is True
+
+    def test_stable_app_never_auto_routes(self, monkeypatch):
+        """D-23 preserved, now on the install=False path too."""
+        import firestarter as _pkg
+        from firestarter.cli_handlers import _maybe_auto_route_to_pre
+
+        monkeypatch.setattr(_pkg, "__version__", "2.0.7")
+        for install in (True, False):
+            args = self._args(install=install)
+            _maybe_auto_route_to_pre(args)
+            assert args.pre is False
+
+    def test_explicit_stable_opts_out_without_install(self, monkeypatch):
+        """D-24 preserved on the widened condition."""
+        import firestarter as _pkg
+        from firestarter.cli_handlers import _maybe_auto_route_to_pre
+
+        monkeypatch.setattr(_pkg, "__version__", "3.0.0b21")
+        args = self._args(install=False, stable=True)
+        _maybe_auto_route_to_pre(args)
+        assert args.pre is False
+
+    def test_explicit_pinned_version_opts_out_without_install(self, monkeypatch):
+        import firestarter as _pkg
+        from firestarter.cli_handlers import _maybe_auto_route_to_pre
+
+        monkeypatch.setattr(_pkg, "__version__", "3.0.0b21")
+        args = self._args(install=False, firmware_version="2.0.6")
+        _maybe_auto_route_to_pre(args)
+        assert args.pre is False
+
+    def test_explicit_pre_does_not_double_log_without_install(
+        self, monkeypatch, caplog
+    ):
+        import firestarter as _pkg
+        from firestarter.cli_handlers import _maybe_auto_route_to_pre
+
+        monkeypatch.setattr(_pkg, "__version__", "3.0.0b21")
+        args = self._args(install=False, pre=True)
+        with caplog.at_level(logging.INFO):
+            _maybe_auto_route_to_pre(args)
+        assert not any("beta app detected" in r.message.lower() for r in caplog.records)

--- a/tests/test_serial_comm.py
+++ b/tests/test_serial_comm.py
@@ -388,7 +388,7 @@ def test_find_and_connect_threads_fault_inject_outgoing(monkeypatch) -> None:
     monkeypatch.setattr(
         SerialCommunicator,
         "_list_potential_ports",
-        staticmethod(lambda p=None: ["/dev/fake0"]),
+        staticmethod(lambda p=None, **_kw: ["/dev/fake0"]),
     )
     monkeypatch.setattr(SerialCommunicator, "_probe_port", staticmethod(fake_probe))
 
@@ -419,7 +419,7 @@ def test_find_and_connect_default_no_fault_inject(monkeypatch) -> None:
     monkeypatch.setattr(
         SerialCommunicator,
         "_list_potential_ports",
-        staticmethod(lambda p=None: ["/dev/fake0"]),
+        staticmethod(lambda p=None, **_kw: ["/dev/fake0"]),
     )
     monkeypatch.setattr(SerialCommunicator, "_probe_port", staticmethod(fake_probe))
 


### PR DESCRIPTION
## Summary

A pre-release host could not update firmware on a board running older firmware — the exact case a user hits when moving off a stable release. Four defects, found by exercising every firmware-update path on the bench.

**The headline case:** a board on genuine stable `2.0.6` could not be updated *at all*, and the error told the user to run `firestarter fw --install`, which re-entered the same failure. There was no in-app upgrade path off old firmware.

## The defects

**1. The version gate blocked the one command that fixes an outdated version.** `_probe_port` refuses any ack without the CAP-02 identity tail, and `manage_firmware_update` calls `check_current_firmware` as its first statement. Firmware predating CAP-02 (b1–b18) therefore aborted `fw`, `fw --install` and `fw --force` before the update decision — while the version sat in the very next ack as `OK: FW: 3.0.0b11:uno`. Fixed with an explicit `allow_outdated_firmware` waiver (default **False**) scoped to the version refusals only; the shield-revision gate is untouched and chip-operation paths still refuse, pinned by a source-level tripwire.

Alongside it, `_maybe_auto_route_to_pre` gated the pre-channel auto-route on `--install`, so a beta app resolved the **stable** channel for bare `fw` and `fw --force` — which made `--force` resolve `2.0.6`, a downgrade onto firmware this host cannot speak to.

**2. `--port` ordered the probe list instead of restricting it.** When the named port did not answer, probing continued and the caller got a *different* board's identity. Measured on the bench: with 2.0.6 on `/dev/ttyACM1` and a uno328pb on `/dev/ttyUSB0`, `fw --port /dev/ttyACM1 --install` downloaded `firestarter_uno328pb.hex` and ran `avrdude -p atmega328pb -c urclock -P /dev/ttyACM1`. Only avrdude's part-signature check stopped a wrong-firmware flash.

The rule is deliberately two-sided: a port **typed this invocation** is obeyed exactly, while a port merely **remembered in config** still yields to discovery — otherwise replugging a board would strand every later invocation on a port that no longer exists.

**3. Firmware too old to speak the protocol could never be replaced.** avrdude drives the **bootloader**, not the firmware, so an install never needs the running image to be readable. It does need to know *which* image to write, so `--install`/`--force` on an unidentified programmer now refuse unless `--board` names it, and warn when they proceed. Portless (DFU) boards are exempt — a py32f071 exposes no serial port, so "unidentified" is its normal state.

**4. A one-shot `--port` leaked into the persisted config.** `_save_config` dumped the whole in-memory dict, so caching `avrdude-path` after a successful flash wrote a `--port` that is documented as applying to one invocation. Observed live: `~/.firestarter/config.json` acquired `"port": "/dev/ttyUSB0"`, silently retargeting every later command.

## Review notes — please read these two

**Two commits here fix incomplete earlier commits in this same series, and that is deliberate history.** Both original defects existed because *two places had to agree*, and the first fix repaired only one:

- `94d327d` — the config leak had **two** persisted writers (the successful probe in `serial_comm`, the successful flash in `firmware`). Fixing the first left the leak fully live on the install path. Now chokepointed at `ConfigManager.remember_port()`, with a source tripwire pinning it as the only writer.
- `c495e98` — `--port` restriction closed the *typed* path, but `port_override` is read back out of config, so a *remembered* port did not restrict, and `port_to_use = port_override or connected_port` still preferred it: board Y identified, Y's asset aimed at port X. Inverted to `connected_port or port_override`, which makes the mismatch unrepresentable rather than caught by avrdude — a guard that only helps while two boards have different MCUs, since two Unos are both `atmega328p -c arduino`.

I left these as separate commits rather than squashing, because "only one of two agreeing call sites was fixed" is the useful signal for reviewing this area.

**One change is not verifiable on hardware and I want that visible:** the portless/DFU exemption in defect 3. No PY32F071 silicon exists (no PCB, never run on hardware), so that branch is unit-test-only and is the least-proven line in this PR.

## Bench verification

| Path | Board | Result |
|---|---|---|
| `fw --install` | uno / leonardo / uno328pb | b11→b19, b17→b19, b11→b19 |
| `--board X --install` from unreachable firmware | uno (2.0.6), leonardo (2.0.6), uno328pb (b4) | all → b19 |
| `--firmware-version X --force` | uno, uno328pb | pinned downgrades incl. across a major |
| restricted read on a mute board | uno, leonardo | names the port; no longer answers with another board's version |
| bogus `--port`, 3 boards attached | — | refuses instead of silently using one |
| stale remembered port | — | falls through to discovery **and** self-heals config |
| `hw` (negative control) | uno | refuses pre-CAP-02, works after upgrade — gate intact |

All three flash methods are proven under the blind-install branch: `arduino`, `avr109` (which alone exercises the 32u4-only 1200-baud touch), and `urclock`.

**Measured framing boundary:** `2.0.6` → `Bad JSON`, `3.0.0b4` → `Bad JSON`, `3.0.0b11` → acks *without* the identity tail. The split is the COBS pivot at firmware **b8**, so the two populations are distinct: pre-b8 needs the blind install, b8–b18 needs the CAP-02 waiver. An earlier version of the not-found message blamed "2.x" alone; bench-testing b4 disproved that and it was corrected.

## Gates (Python 3.11, matching `ci.yml`, on this branch's base)

- catalog validity + both codegen drift gates — **ZERO DIFF**
- `ruff check` / `ruff format --check` — clean
- mypy **watermark gate** — 33 errors vs watermark 35, 139 files, exit 0
- `pytest --cov-fail-under=70` — **1625 passed, 0 failed**, coverage **83.27%**
- console-script smoke test, and the isolated `ci-py32` leg (pyusb imports, 6/6)

## Scope

Branched from `beta` and cherry-picked, deliberately **not** raised from the `v1.32` milestone branch — that branch carries 32 further commits of unfinished work including a breaking chip-database schema migration, which does not belong in this review.

Debug session: `.planning/debug/fw-update-blocked-release-fw.md` (meta repo).
