### PR TITLE
chore: strip GSD provenance from the host app package and tools

### DIFF
--- a/firestarter/channel.py
+++ b/firestarter/channel.py
@@ -38,8 +38,8 @@ BETA_ONLY_BOARDS: tuple[str, ...] = ("py32f071",)
 
 # The seven `dev` subcommands gated by channel on a stable build
 # (136-CONTEXT.md "Measured baseline": 8 total `dev` subcommands, minus
-# `read`/`test` which stable keeps, PLUS Phase 151 / D-01's `lock-status` —
-# a real silicon read D-01 deliberately overruled the host-only
+# `read`/`test` which stable keeps, PLUS `lock-status` —
+# a real silicon read that deliberately overruled the host-only
 # recommendation to expose, only on a pre-release install — bringing the
 # total to 9 and the gated count to seven, up by one). Consulted for the
 # informative-refusal message ONLY, by `_DevGroup.get_command` in

--- a/firestarter/chip_test.py
+++ b/firestarter/chip_test.py
@@ -367,7 +367,7 @@ _SDP_LEG_STEP_ORDER: tuple[str, ...] = (
 # erase `locked_destructive` reasons already use above -- naming the SDP
 # leg's own governing decision rather than reusing D-01's tag on a
 # reason it does not own.
-_SDP_LOCKED_REASON = 'write_scope="none": {op} omitted (D-18)'
+_SDP_LOCKED_REASON = 'write_scope="none": {op} omitted'
 
 # Region-policy vocabulary. Plain
 # module-level strings mirroring how this module already carries its op
@@ -704,9 +704,7 @@ def derive_plan(name: str, db: Any, *, write_scope: str = "none") -> Plan:
             )
         )
     else:
-        locked_destructive.append(
-            (OP_WRITE, 'write_scope="none": write omitted (D-01)')
-        )
+        locked_destructive.append((OP_WRITE, 'write_scope="none": write omitted'))
 
     # verify: always supported, but only executable on a write-executing
     # plan -- it follows the same D-01 write/erase gating (there is no
@@ -732,9 +730,7 @@ def derive_plan(name: str, db: Any, *, write_scope: str = "none") -> Plan:
             )
         )
     else:
-        locked_destructive.append(
-            (OP_VERIFY, 'write_scope="none": verify omitted (D-01)')
-        )
+        locked_destructive.append((OP_VERIFY, 'write_scope="none": verify omitted'))
 
     # erase: supported only if FLAG_CAN_ERASE is set AND protocol != 0x05
     # (flash4 auto-erases per page; the flag is deliberately clear for it --
@@ -752,9 +748,7 @@ def derive_plan(name: str, db: Any, *, write_scope: str = "none") -> Plan:
             # appended below -- the leg stays a contiguous terminal block.
             steps.append(blank_check_step)
         else:
-            locked_destructive.append(
-                (OP_ERASE, 'write_scope="none": erase omitted (D-01)')
-            )
+            locked_destructive.append((OP_ERASE, 'write_scope="none": erase omitted'))
     else:
         if protocol == _PROTOCOL_FLASH4:
             reason = "flash4 (0x05) auto-erases per page; no separate erase op"
@@ -869,7 +863,7 @@ def _top_anchored_or_default(full: dict) -> tuple[int, int]:
     default `(_WRITE_REGION_START, _WRITE_REGION_LENGTH)` when `memory-size`
     is missing or too small (a fallback that would otherwise produce a
     negative start). The WIDTH always comes from the `_UV_WRITE_REGION_LENGTH`
-    module constant -- never from any DB field (SC4); `memory-size` only
+    module constant -- never from any DB field; `memory-size` only
     bounds WHERE the window sits. Never returns `None` -- both callers
     (`write_scope="full"` for a UV part, `write_scope="partial"`
     unconditionally) want a concrete region, not "use the engine default"
@@ -1033,7 +1027,7 @@ class StepResult:
 
     `verdict` is one of OK/BAD/NA/SKIPPED/marginal. `error_code` carries the
     exact firmware `response.id` captured off `EpromOperationError.error_code`
-    (RPT-03) when the step raised; `None` otherwise. `fingerprint` is attached
+    when the step raised; `None` otherwise. `fingerprint` is attached
     only for the write/verify step (Task 3, PATT-02 wiring). `run_count` is
     the number of times the underlying operator method was actually invoked
     for this step (1 for single-run steps; N for multi-run destructive/verify
@@ -1318,7 +1312,7 @@ def _aggregate_cycle_results(results: list[StepResult], op: str) -> StepResult:
     verdicts = {r.verdict for r in ran}
     if len(verdicts) > 1:
         verdict = VERDICT_MARGINAL
-        reason = f"{len(ran)} cycles disagreed on outcome (D-06 marginal policy)"
+        reason = f"{len(ran)} cycles disagreed on outcome"
     else:
         verdict = ran[0].verdict
         reason = next((r.reason for r in ran if r.reason), "")
@@ -1641,7 +1635,7 @@ def run_plan(
                 verdict=VERDICT_BAD,
                 reason=(
                     f"runs must be >= 2 (got {runs}); a destructive/verify "
-                    "step requires at least 2 runs to compare (D-05) -- "
+                    "step requires at least 2 runs to compare -- "
                     "pass allow_single_run=True to run a deliberately "
                     "weaker single-run plan"
                 ),
@@ -1996,7 +1990,7 @@ def sdp_left_writable(results: list[StepResult]) -> bool:
 _WRITE_REGION_START = 0
 _WRITE_REGION_LENGTH = 256
 
-# UV-EPROM write-region WIDTH (SC4). This is an ENGINE MODULE
+# UV-EPROM write-region WIDTH. This is an ENGINE MODULE
 # CONSTANT, never sourced from any DB field -- a malicious/misconfigured DB
 # entry must not be able to widen the write window. `memory-size` is only a
 # top-anchor PLACEMENT bound (where the window sits), never a WIDTH input.
@@ -2344,7 +2338,7 @@ def _write_region_for(step: Step | None, eprom_data: dict[str, Any]) -> tuple[in
     call-site symmetry with `_dispatch_multi_run`'s existing signature but is
     otherwise unused by this function: the WIDTH always comes from a module
     constant (`_WRITE_REGION_LENGTH` / `_UV_WRITE_REGION_LENGTH`), never from
-    any DB field (SC4) -- `eprom_data`/`memory-size` play no role here
+    any DB field -- `eprom_data`/`memory-size` play no role here
     because `derive_plan` already resolved the concrete region.
     """
     if step is not None and step.write_region is not None:
@@ -3140,7 +3134,7 @@ def _dispatch_multi_run(
     error_code, error_message = _firmware_error(operator)
     if diverged:
         verdict = VERDICT_MARGINAL
-        reason = f"{runs} runs disagreed on outcome (D-06 marginal policy)"
+        reason = f"{runs} runs disagreed on outcome"
     else:
         verdict = VERDICT_OK if outcomes and outcomes[0] else VERDICT_BAD
         # The firmware's text becomes the step's reason ONLY on a non-OK
@@ -3250,8 +3244,8 @@ def _dispatch_sdp_leg(
     `True` is reachable only when the state machine succeeded AND (for the
     inhibited-write op) the ack was observed internally by
     `eprom_operations.py`'s own check (`:1654-1662`) -- so `True` proves the
-    experiment ran as designed. `False` NEVER means BAD by itself (D-01/
-    D-02) -- it routes to `marginal`, naming both candidate causes (the
+    experiment ran as designed. `False` NEVER means BAD by itself -- it routes
+    to `marginal`, naming both candidate causes (the
     opt-out not honoured by older firmware, or a transport fault).
 
     ⚠ D-03's full 2x2 polarity proof holds for `OP_WRITE_INHIBITED`:
@@ -3383,7 +3377,7 @@ def _dispatch_sdp_leg(
                 "correct-length but degenerate read-back content "
                 f"(classification={fingerprint.classification!r}) — a "
                 "loose socket or blank/unresponsive chip reads as a contact "
-                "fault, not a chip finding (D-04)"
+                "fault, not a chip finding"
             ),
             fingerprint=fingerprint,
             run_count=1,
@@ -3420,7 +3414,7 @@ def _dispatch_sdp_leg(
                 (
                     "write_eprom reported failure on the inhibited-write "
                     "precondition — this is a PRECONDITION signal, not the "
-                    "verdict (D-01). Most likely causes: (1) the 0x86 opt-out "
+                    "verdict. Most likely causes: (1) the 0x86 opt-out "
                     "ack was not honoured — the connected firmware may predate "
                     "FLAG_SKIP_SDP_UNLOCK support, run `firestarter fw "
                     "--install` to update it and retry; or (2) a transport "
@@ -3438,8 +3432,8 @@ def _dispatch_sdp_leg(
                 (
                     "write_eprom reported success but the read-back does not "
                     "match what was written — the write path did not "
-                    "transition (LEG-16's dead-write-path shape) or changed "
-                    "only part of the region (LEG-07)"
+                    "transition (a dead write path) or changed "
+                    "only part of the region"
                 ),
             )
         elif (not wrote_ok) and equal:

--- a/firestarter/chip_test.py
+++ b/firestarter/chip_test.py
@@ -44,7 +44,7 @@ from firestarter.exceptions import (
     ProgrammerNotFoundError,
     SerialError,
 )
-from firestarter.sdp_capability import sdp_capability  # LEG-01/02's derivation source
+from firestarter.sdp_capability import sdp_capability  # the SDP leg's derivation source
 
 # ---------------------------------------------------------------------------
 # Address-derived pattern generator
@@ -68,7 +68,7 @@ def generate_pattern(start: int, length: int) -> bytes:
     Derives each byte from its ABSOLUTE address (`start + i`), never from
     the offset alone -- no full-chip assumption is baked in, so this same
     function serves both a full-chip pattern and a small high-address
-    region (Phase 109's UV small-region write cap).
+    region (the UV small-region write cap).
     """
     return bytes(address_fold_byte(start + i) for i in range(length))
 
@@ -102,14 +102,14 @@ def prepass_images(length: int) -> tuple[bytes, bytes]:
 
 
 # ---------------------------------------------------------------------------
-# Shared byte-diff-offset helper (D-04 -- reused, not reimplemented)
+# Shared byte-diff-offset helper -- reused, not reimplemented
 # ---------------------------------------------------------------------------
 #
 # Mirrors the exact divergence math in `consistency_check_eprom`
 # (eprom_operations.py:842-863): cmp_len / diff_offsets / pct / first
 # divergence offset. This is the ONE divergence primitive `classify_fingerprint`
 # consumes -- do NOT add a second parallel divergence implementation
-# elsewhere in this codebase (D-04 mandate). The math is small enough to
+# elsewhere in this codebase. The math is small enough to
 # copy rather than import, keeping this module import-light (no dependency
 # on eprom_operations.py).
 
@@ -168,7 +168,7 @@ def classify_fingerprint(
 ) -> Fingerprint:
     """Classify a byte-mismatch pattern into one of four honest buckets.
 
-    Consumes the shared `_diff_offsets` divergence primitive (D-04 -- the
+    Consumes the shared `_diff_offsets` divergence primitive (the
     same math `consistency_check_eprom` uses for run1-vs-run2 divergence,
     here applied to expected-pattern-vs-read-back). Never writes a second
     divergence implementation.
@@ -365,7 +365,7 @@ _SDP_LEG_STEP_ORDER: tuple[str, ...] = (
 # The `write_scope="none"` advisory prose, in the same
 # `'write_scope="none": ... omitted'` shape the shipped write/verify/
 # erase `locked_destructive` reasons already use above -- naming the SDP
-# leg's own governing decision rather than reusing D-01's tag on a
+# leg's own governing decision rather than reusing the write-scope tag on a
 # reason it does not own.
 _SDP_LOCKED_REASON = 'write_scope="none": {op} omitted'
 
@@ -606,7 +606,7 @@ def derive_plan(name: str, db: Any, *, write_scope: str = "none") -> Plan:
     # and AT28C256's plan alone carries six region-sized write-shaped SDP
     # ops that would otherwise become six full-device transfers per run.
     # The leg's live path is always the full scope (SDP-ALLOW chips are all
-    # non-UV, D-17), so `leg_region` is `(0, 256)` on every reachable run
+    # non-UV), so `leg_region` is `(0, 256)` on every reachable run
     # and the leg's wire behaviour is unchanged by this task.
     leg_region = (
         _DEFAULT_REGION
@@ -707,7 +707,7 @@ def derive_plan(name: str, db: Any, *, write_scope: str = "none") -> Plan:
         locked_destructive.append((OP_WRITE, 'write_scope="none": write omitted'))
 
     # verify: always supported, but only executable on a write-executing
-    # plan -- it follows the same D-01 write/erase gating (there is no
+    # plan -- it follows the same write/erase gating (there is no
     # preceding write on a non-executing run, so a bare verify would compare
     # a freshly-generated pattern against unrelated chip contents).
     # Positioned after write and before erase so the destructive step order
@@ -755,7 +755,7 @@ def derive_plan(name: str, db: Any, *, write_scope: str = "none") -> Plan:
         elif etype == "UV-EPROM":
             reason = "UV-EPROM has no electrical erase (UV light only)"
         elif protocol == _PROTOCOL_EEPROM_28C:
-            # DEFENSIVE FALLTHROUGH (Phase 153, ERASE-03/ERASE-04 -- see
+            # DEFENSIVE FALLTHROUGH -- see
             # `_PROTOCOL_EEPROM_28C`'s own comment above for the full
             # disposition). This arm is unreachable from the shipped
             # database now that FLAG_CAN_ERASE is restored on all 84
@@ -782,7 +782,7 @@ def derive_plan(name: str, db: Any, *, write_scope: str = "none") -> Plan:
             Step(op=OP_ERASE, supported=False, reason=reason, destructive=True)
         )
 
-    # SDP leg emission (v1.30 Phase 134, D-06/D-07/D-18/D-20, LEG-01/02/04).
+    # SDP leg emission.
     # Appended as a CONTIGUOUS block at the END of the step list, after the
     # erase arm -- no shipped step's index moves (the existing
     # `d_ops.index(OP_VERIFY) < d_ops.index(OP_ERASE)`-shaped comparisons
@@ -791,7 +791,7 @@ def derive_plan(name: str, db: Any, *, write_scope: str = "none") -> Plan:
     # heuristic; `sdp_capability` is itself fail-closed and count-pinned at
     # 43 ALLOW / 41 REFUSE / 84 total. No new CLI option is introduced by
     # this: `derive_plan`'s signature gains no parameter, so `dev test`
-    # keeps zero options (LEG-01's own constraint).
+    # keeps zero options.
     sdp_allowed, sdp_reason = sdp_capability(name, db)
     if write_execute:
         if sdp_allowed:
@@ -818,7 +818,7 @@ def derive_plan(name: str, db: Any, *, write_scope: str = "none") -> Plan:
             # sdp_capability()'s OWN refusal prose verbatim.
             # `run_plan:877-879`'s existing NA path turns each into a
             # `_skip_result(..., verdict=VERDICT_NA)` with NO operator
-            # call -- zero new machinery needed for LEG-02.
+            # call -- zero new machinery needed.
             for sdp_op in _SDP_LEG_STEP_ORDER:
                 steps.append(
                     Step(
@@ -830,10 +830,10 @@ def derive_plan(name: str, db: Any, *, write_scope: str = "none") -> Plan:
                 )
     elif sdp_allowed:
         # ALLOW chip, write_scope="none": all six steps go to the advisory
-        # `locked_destructive` list instead of `steps` (D-18, mirroring the
+        # `locked_destructive` list instead of `steps` (mirroring the
         # shipped write/verify/erase treatment above) -- these entries DO
         # count toward count_applicable's M, so N < M and the banner fires,
-        # matching D-15's polarity.
+        # matching its polarity.
         for sdp_op in _SDP_LEG_STEP_ORDER:
             locked_destructive.append((sdp_op, _SDP_LOCKED_REASON.format(op=sdp_op)))
     # else: a REFUSE chip at write_scope="none" emits NOTHING -- neither a step
@@ -876,7 +876,7 @@ def _top_anchored_or_default(full: dict) -> tuple[int, int]:
 
 
 # ---------------------------------------------------------------------------
-# Non-fatal per-step executor (SWEEP-02/03/04, RPT-03) -- guard-HONORING
+# Non-fatal per-step executor -- guard-HONORING
 # execution path
 # ---------------------------------------------------------------------------
 #
@@ -888,8 +888,8 @@ def _top_anchored_or_default(full: dict) -> tuple[int, int]:
 # dispatches to the existing EpromOperator methods only -- it sets no VPP,
 # builds no wire dict, and passes no --force.
 
-# Verdict vocabulary. `MARGINAL` is destructive/verify-only (D-06,
-# wired in Task 3) -- never forced onto read-step disagreement.
+# Verdict vocabulary. `MARGINAL` is destructive/verify-only -- never forced
+# onto read-step disagreement.
 VERDICT_OK = "OK"
 VERDICT_BAD = "BAD"
 VERDICT_NA = "NA"
@@ -1010,7 +1010,7 @@ _DESTRUCTIVE_GATE_REASON = (
 # baseline write/read-back transition did not complete; the part is left as
 # found) -- never a mechanism name, and never `_DESTRUCTIVE_GATE_REASON`'s
 # chip-ID wording, which would mislead a reader into thinking chip-ID
-# closed the gate when the write path did (D-08's own rejected alternative).
+# closed the gate when the write path did -- a rejected alternative.
 _SDP_BASELINE_GATE_REASON = (
     "baseline write/read-back transition did not complete — "
     "no lock was emitted (part left as found)"
@@ -1023,15 +1023,15 @@ _SDP_UNLOCK_GATE_REASON = (
 
 @dataclass
 class StepResult:
-    """Outcome of executing a single `Step` (SWEEP-02/03/04, RPT-03).
+    """Outcome of executing a single `Step`.
 
     `verdict` is one of OK/BAD/NA/SKIPPED/marginal. `error_code` carries the
     exact firmware `response.id` captured off `EpromOperationError.error_code`
     when the step raised; `None` otherwise. `fingerprint` is attached
-    only for the write/verify step (Task 3, PATT-02 wiring). `run_count` is
+    only for the write/verify step. `run_count` is
     the number of times the underlying operator method was actually invoked
     for this step (1 for single-run steps; N for multi-run destructive/verify
-    steps, Task 3). `divergence` carries the read-step byte-level divergence
+    steps). `divergence` carries the read-step byte-level divergence
     metric when the step's `runs` disagreed -- a metric only, never a
     verdict flip and never `marginal` (marginal is destructive/verify-only).
     """
@@ -1054,7 +1054,7 @@ class StepResult:
     # -- additive, `None` on every step that isn't a write, and `None` on a
     # write step that was SKIPPED as saturated/refused (in which case
     # `reason` names why). The verify step INHERITS this value from
-    # `WriteContext` rather than re-resolving it (D-07 moved to execution
+    # `WriteContext` rather than re-resolving it (the seam moved to execution
     # time) -- it never appears on a verify step's OWN `StepResult` (verify
     # reads the context, it does not set this field on itself).
     write_target: WriteTarget | None = None
@@ -1392,7 +1392,7 @@ def _plan_cycle_targets(
 
 
 def _alternating_cycle_targets(target: WriteTarget, cycles: int) -> list[WriteTarget]:
-    """D-2's `alternate` recipe: pattern, complement, pattern, ...
+    """The `alternate` recipe: pattern, complement, pattern, ...
 
     For SRAM/FRAM, which are freely rewritable in BOTH bit directions, so a
     differing payload costs nothing and the complement additionally exercises
@@ -1417,7 +1417,7 @@ def _alternating_cycle_targets(target: WriteTarget, cycles: int) -> list[WriteTa
 
 
 def _uv_cycle_targets(target: WriteTarget, cycles: int) -> list[WriteTarget]:
-    """D-2's `uv-tranche` recipe: N cumulative images out of ONE slot.
+    """The `uv-tranche` recipe: N cumulative images out of ONE slot.
 
     Empty list when the slot cannot be staged -- see `_plan_cycle_targets`'s
     defensive fallback for why that is unreachable through the normal path.
@@ -1454,7 +1454,7 @@ def _uv_cycle_targets(target: WriteTarget, cycles: int) -> list[WriteTarget]:
                     # Carried through from the probe target, NOT dropped: the
                     # staged copies describe the SAME slot, and these are the
                     # only targets that ever reach the report -- leaving them
-                    # None made D-9's rig-life line invisible on exactly the
+                    # None made the rig-life line invisible on exactly the
                     # family it exists for (caught by running it, not by the
                     # suite).
                     slots_remaining=target.slots_remaining,
@@ -1513,7 +1513,7 @@ def _run_cycle_block(
 
     per_step: list[list[StepResult]] = [[] if r is None else [r] for r in pre]
     live = [i for i, r in enumerate(pre) if r is None]
-    # SAFE-02 retry guard, preserved across the move to a cycle loop: a
+    # Retry guard, preserved across the move to a cycle loop: a
     # firmware ERROR response (a non-None `error_code` -- the VPP-out-of-range
     # guard refusal 0xA9 is the case that motivated it) is a FINDING, not
     # something to retry. Before the cycle loop the raised exception aborted
@@ -1659,7 +1659,7 @@ def run_plan(
     # zero-argument callables, deliberately GENERIC rather than a hardcoded
     # lock-to-unlock window with the unlock written inline. The inline form
     # is literally what research P-20 prevention #2 describes and is
-    # simpler -- but Phase 134's four-step leg, and any later
+    # simpler -- but the four-step SDP leg, and any later
     # cleanup-needing op, would each have to re-open `run_plan` to widen
     # the special case, and a special case widened three times is how this
     # loop's flat shape rotted in the first place. Drained in
@@ -1667,11 +1667,11 @@ def run_plan(
     # measured, not assumed, `ExitStack.close()` drains LIFO (reversing
     # registration order) and a raising callback makes `close()` re-raise,
     # which inside a `finally` REPLACES the in-flight exception and demotes
-    # the original to `__context__` -- precisely the masking D-10 exists to
+    # the original to `__context__` -- precisely the masking this exists to
     # prevent.
     cleanup: list[Callable[[], None]] = []
 
-    # De-registration handle (v1.30 Phase 134, plan 134-04, D-11/RESEARCH
+    # De-registration handle (see the SDP-unlock discussion in
     # §4.2). With this phase's explicit `sdp-unlock` step now a real plan
     # step, a successful lock both REGISTERS a cleanup (above) AND the plan
     # step RUNS the unlock explicitly -- two unlock emissions without this
@@ -1688,7 +1688,7 @@ def run_plan(
     # call below. `derive_plan` still decides the REGION and POLICY; this
     # object carries the MASK decision (necessarily execution-time) from
     # the blank-check step -> the write step -> the verify step, so the
-    # verify step never re-derives either. This is the D-07 seam MOVED to
+    # verify step never re-derives either. This is the seam MOVED to
     # execution time.
     write_context = WriteContext()
 
@@ -1773,7 +1773,7 @@ def run_plan(
 
             if step.op in (OP_WRITE, OP_WRITE_PARTIAL):
                 # The verify step inherits the write's ACTUAL resolved
-                # target (or refusal) -- never re-derived (D-07 moved to
+                # target (or refusal) -- never re-derived (moved to
                 # execution time).
                 write_context.target = result.write_target
                 write_context.refusal = (
@@ -1811,7 +1811,7 @@ def run_plan(
                 cleanup.append(_unlock_cleanup)
                 # Hold the handle so a later successful EXPLICIT unlock step
                 # (below) can de-register it -- see `unlock_cleanup`'s own
-                # comment above (D-11/RESEARCH §4.2).
+                # comment above.
                 unlock_cleanup = _unlock_cleanup
 
             if (
@@ -1823,7 +1823,7 @@ def run_plan(
                 # registered cleanup from the matching lock above is no
                 # longer needed -- remove it by VALUE (`cleanup.remove`),
                 # never by wiping the whole registry, so a completed leg
-                # emits exactly one `sdp_unlock` call, not two (D-11/
+                # emits exactly one `sdp_unlock` call, not two (
                 # RESEARCH §4.2). A FAILED explicit unlock (non-OK verdict)
                 # deliberately leaves `unlock_cleanup` registered so the
                 # `finally` drain below still retries it.
@@ -1871,7 +1871,7 @@ def run_plan(
 
 
 def _id_step_closes_gate(result: StepResult) -> bool:
-    """SWEEP-03: close the destructive gate on an id-check failure/mismatch.
+    """Close the destructive gate on an id-check failure/mismatch.
 
     Closes on `is_ok is False` (chip-ID check failed), a detected id that
     differs from the DB's expected `chip-id` (Pitfall 4's explicit mismatch
@@ -1885,7 +1885,7 @@ def _id_step_closes_gate(result: StepResult) -> bool:
 
 
 def _baseline_closes_sdp_gate(result: StepResult) -> bool:
-    """D-08/D-20: close the SDP baseline gate on ANY non-OK baseline verdict.
+    """Close the SDP baseline gate on ANY non-OK baseline verdict.
 
     Mirrors `_id_step_closes_gate`'s shape immediately above -- a pure
     `StepResult -> bool` predicate `run_plan` consults after running one of
@@ -1903,8 +1903,8 @@ def _baseline_closes_sdp_gate(result: StepResult) -> bool:
     return result.verdict != VERDICT_OK
 
 
-# LEG-12's three-valued hold-state REPORT VALUES (v1.30 Phase 134, plan
-# 134-04, D-10/D-12/D-15). These are report values, NOT op strings -- they
+# Three-valued hold-state REPORT VALUES. These are report values, NOT op
+# strings -- they
 # carry no `OP_` prefix and must never join `_ALL_OPS`/`_MULTIWORD_OP_VALUES`
 # in tests/test_op_registration_parity.py; a later reader must not
 # "helpfully" register them there.
@@ -1919,14 +1919,14 @@ def sdp_oracle_applicable(plan: Plan) -> bool:
     Derived STRUCTURALLY from the `plan` object the caller already holds --
     never a second call to `sdp_capability`, which would be a second source
     of truth that could drift from `derive_plan`'s own decision (the same
-    single-source-of-truth discipline D-15 applies to `count_applicable`).
+    single-source-of-truth discipline applied to `count_applicable`).
 
     `True` when `plan.steps` carries an `OP_WRITE_INHIBITED` `Step` with
     `supported=True` (a real `dev test` run, ALLOW chip), OR when
     `plan.locked_destructive` carries an `OP_WRITE_INHIBITED` `(op, reason)`
     pair (the `write_scope="none"` ALLOW-chip shape). `False` for a
     REFUSE chip: its `OP_WRITE_INHIBITED` step IS present in `plan.steps`
-    (LEG-02's NA path), but with `supported=False` -- the oracle never runs
+    (the NA path), but with `supported=False` -- the oracle never runs
     for a REFUSE chip, so that presence must not count as "applicable".
     """
     for step in plan.steps:
@@ -1983,9 +1983,9 @@ def sdp_left_writable(results: list[StepResult]) -> bool:
 
 
 # Region used for the write/verify address-derived pattern fingerprint
-# (Task 3, PATT-01/02 wiring). A small fixed region keeps the bench-free
+# A small fixed region keeps the bench-free
 # engine's write/verify step cheap and matches the region-parameterized
-# generator contract. This is the NON-UV default region -- Phase 109
+# generator contract. This is the NON-UV default region --
 # owns the UV-EPROM branch below via `_write_region_for`.
 _WRITE_REGION_START = 0
 _WRITE_REGION_LENGTH = 256
@@ -1999,7 +1999,7 @@ _WRITE_REGION_LENGTH = 256
 # SLOT width -- the granularity `uv_slot_starts`/`WriteTarget` operate at --
 # and it is the BOUND D-E requires on the reversal below: `full_device_region`
 # derives a write WIDTH from `memory-size` for the non-UV full-device policy,
-# which deliberately reverses SC4/D-01's "width never comes from the DB" rule
+# which deliberately reverses the "width never comes from the DB" rule
 # on that one path -- but only after a sanity check, and never for this slot
 # width, which stays a module constant on every path.
 _UV_WRITE_REGION_LENGTH = 256
@@ -2090,7 +2090,7 @@ def bits_cleared_by(current: bytes, desired: bytes) -> int:
 
 
 def uv_tranche_images(current: bytes, desired: bytes, cycles: int) -> list[bytes]:
-    """Stage `current & desired` across `cycles` writes -- D-2's UV recipe.
+    """Stage `current & desired` across `cycles` writes -- the UV recipe.
 
     Returns `cycles` CUMULATIVE images: image *n* is `current` with tranches
     0..*n* cleared, so image `cycles-1` is exactly `current & desired`.
@@ -2243,7 +2243,7 @@ class WriteTarget:
     (meaningless, and not checked, when `masked` is False); `current_source`
     names where the "current chip content" came from for a masked target
     (a probe read, or the blank-check for D-C) -- provenance for the report,
-    Task 5.
+
     """
 
     region: tuple[int, int]
@@ -2325,13 +2325,13 @@ def _write_region_for(step: Step | None, eprom_data: dict[str, Any]) -> tuple[in
     when `step` is `None` or carries no region (`step.write_region is
     None`).
 
-    This function must NEVER re-derive UV-ness. Before Phase 121 Plan 06 it
+    This function must NEVER re-derive UV-ness. An earlier revision
     guessed UV-ness at execution time from `eprom_data.get("electrical-type")
     == "UV-EPROM"` OR `eprom_data.get("algorithm") == 0x0B` -- but
     `_dispatch_multi_run`'s `eprom_data` is `resolve_chip`'s PROGRAMMER dict
     (via `convert_to_programmer`), which never carries `electrical-type`,
     and `algorithm == 0x0B` matches only 32 of 301 UV parts (measured), so
-    269 UV parts silently fell through to the engine default. Under D-01, a
+    269 UV parts silently fell through to the engine default. A
     missed UV part receiving a full-device write instead of the small
     top-anchored window is a chip-destroying bug, not a coverage gap -- the
     guess is deleted here, not merely bypassed. `eprom_data` is accepted for
@@ -2507,19 +2507,18 @@ def _dispatch_step(
     single run; read -> `runs`-times with a byte-level divergence metric
     (never a verdict flip); write/verify/erase -> `runs`-times with a
     marginal-on-disagreement policy; write/verify additionally
-    attach a `Fingerprint` (PATT-02 wiring, Pitfall 3 addr_base). SDP
-    lock/unlock -> single run via
-    `_dispatch_sdp`, arm 5. The SDP leg's four write-shaped ops (v1.30 Phase
-    134 T-134-02, LEG-05/06/07/08/16) -> single run via `_dispatch_sdp_leg`,
-    arm 6, LAST -- see below. The engine sets NO VPP, builds NO wire dict
+    attach a `Fingerprint` (addr_base-aware). SDP lock/unlock -> single run
+    via `_dispatch_sdp`, arm 5. The SDP leg's four write-shaped ops -> single
+    run via `_dispatch_sdp_leg`, arm 6, LAST -- see below. The engine sets NO
+    VPP, builds NO wire dict
     (except the one `FLAG_SKIP_SDP_UNLOCK` bit on `OP_WRITE_INHIBITED`, a
-    deliberate D-01 narrowing), and passes NO --force -- it only calls the
+    deliberate narrowing), and passes NO --force -- it only calls the
     operator's existing public methods.
 
     `sampler` is threaded through unchanged to `_dispatch_multi_run`,
     the only op with a bracket site (OP_WRITE); `None` is the default and a
-    proven no-op for every other op. `write_context` (quick task 260821-wna,
-    Task 4) is likewise threaded through to `_dispatch_multi_run` ONLY --
+    proven no-op for every other op. `write_context` is likewise threaded
+    through to `_dispatch_multi_run` ONLY --
     deliberately NOT to `_dispatch_sdp`/`_dispatch_sdp_leg`, which keep
     `_write_region_for` and the fixed leg region unchanged.
     """
@@ -2581,7 +2580,7 @@ def _dispatch_step(
     # something this phase tests.
     if step.op in _SDP_OPS:
         return _dispatch_sdp(step.op, name, eprom_data, operator)
-    # Arm 6 (v1.30 Phase 134 T-134-02, LEG-05/06/07/08/16) -- immediately
+    # Arm 6 -- immediately
     # after arm 5 and still above the terminal fail-closed `return` below.
     # Routes the SDP leg's four write-shaped ops to the read-back-equality
     # oracle. Placing it before arm 5 (or before arms 1-4) would break
@@ -2629,7 +2628,7 @@ def _dispatch_read(
 ) -> StepResult:
     """Run `read_eprom` `runs` times into temp files; report divergence ONLY.
 
-    D-06: read-step disagreement across runs is a byte-level divergence
+    Read-step disagreement across runs is a byte-level divergence
     metric on the step result, NEVER a verdict flip and NEVER `marginal`
     (marginal is destructive/verify-only). The step's own verdict is OK/BAD
     from the LAST run's return value -- disagreement across runs does not
@@ -2803,7 +2802,7 @@ def _resolve_write_target(
 
     mem_size = int(eprom_data.get("memory-size", 0) or 0)
 
-    # D-C's full-device-if-blank branch is GONE (D-4, operator-agreed
+    # The full-device-if-blank branch is GONE (operator-agreed
     # 2026-08-22), and `chip_is_blank`/`full_device_permitted` no longer gate
     # anything on this path. Recorded rather than silently dropped, because it
     # reverses a decision made one day earlier:
@@ -2939,9 +2938,9 @@ def _dispatch_multi_run(
     the expected address-derived pattern and reads back via
     `operator.verify_eprom`'s outcome plus a fresh `read_eprom` to compute
     the `Fingerprint`. Disagreement across the N per-run outcomes
-    -> `marginal`, never coerced to a confident OK/BAD (D-06, the AM27C020
+    -> `marginal`, never coerced to a confident OK/BAD (the AM27C020
     structural case). The write/verify region is READ from `step.
-    write_region` via `_write_region_for(step, eprom_data)` (D-02, Phase 121
+    write_region` via `_write_region_for(step, eprom_data)` (
     Plan 06) -- `derive_plan` already decided it; this function never
     re-derives UV-ness.
 
@@ -2957,15 +2956,15 @@ def _dispatch_multi_run(
     `_write_region_for`/`generate_pattern` and any temp-file creation, so an
     unrecognised op creates no temp file, computes no pattern, and -- the
     load-bearing property -- never reaches ANY of `write_eprom`,
-    `verify_eprom`, or `erase_eprom`. This is the host mirror of Phase 119
-    D-06/D-07's generic op-layer NULL-`main` refusal
+    `verify_eprom`, or `erase_eprom`. This is the host mirror of the firmware's
+    generic op-layer NULL-`main` refusal
     (`firestarter/src/operation_utils.cpp::op_execute_stateful_operation`;
     read-only reference, not re-implemented here). Before this guard, this
     function's run loop ended in a bare `else: # OP_ERASE`, so an unmapped op
     called `operator.erase_eprom()` once per run and reported `VERDICT_OK`
     (RESEARCH Pitfall 1a, proven empirically: 2 runs -> 2 calls -> OK).
 
-    Quick task 260821-wna, Task 4: for `OP_WRITE`/`OP_WRITE_PARTIAL`, the
+    For `OP_WRITE`/`OP_WRITE_PARTIAL`, the
     write target (region + pattern, masked or not) is resolved HERE via
     `_resolve_write_target` -- a saturated/refused target returns SKIPPED
     with the refusal reason and `write_eprom` is NEVER called (the
@@ -3138,7 +3137,7 @@ def _dispatch_multi_run(
     else:
         verdict = VERDICT_OK if outcomes and outcomes[0] else VERDICT_BAD
         # The firmware's text becomes the step's reason ONLY on a non-OK
-        # verdict, and only when the D-06 marginal wording has not already
+        # verdict, and only when the marginal wording has not already
         # claimed the field -- that wording states a policy decision this
         # function made, which must not be overwritten by a per-run detail.
         # The CODE is attached in both cases: it is a separate field and
@@ -3164,7 +3163,7 @@ def _dispatch_sdp(
     Signature is a FORWARD CONTRACT: the same
     first four positional parameters as `_dispatch_multi_run` --
     `(op: str, name: str, eprom_data: dict[str, Any], operator: Any)` --
-    because ROADMAP Phase 134's "Depends on" line names this arm verbatim
+    because the roadmap entry names this arm verbatim
     and builds its four-step leg on it. No keyword-only parameters: SDP
     emissions are single-run (`_MULTI_RUN_OPS` exclusion above), so
     `runs` and `sampler` are deliberately absent here, not merely omitted by
@@ -3199,7 +3198,7 @@ def _dispatch_sdp(
         # silently routed an unmapped op to `erase_eprom()` and reported OK
         # is what this refuses to reintroduce (RESEARCH Pitfall 1a).
         # `AssertionError` is not a `SerialError`, `HardwareOperationError`,
-        # or `EpromOperationError`, so `_run_step`'s D-08 except chain does
+        # or `EpromOperationError`, so `_run_step`'s except chain does
         # not catch it and it escapes loudly -- the intended behaviour,
         # proven by
         # tests/test_chip_test_sdp_leg.py::
@@ -3218,22 +3217,21 @@ def _dispatch_sdp_leg(
     step: Step | None = None,
 ) -> StepResult:
     """Dispatch one of the SDP leg's four write-shaped ops to the
-    READ-BACK-EQUALITY oracle (v1.30 Phase 134, T-134-02, D-01...D-05,
-    LEG-05/06(engine half)/07/08/16).
+    READ-BACK-EQUALITY oracle.
 
     This is the milestone's reason to exist: the verdict comes from
     comparing the read-back bytes against what SHOULD be there, never from
     `write_eprom`'s own bool. A write that returns without error is NOT, by
-    itself, evidence of anything -- see D-01 below.
+    itself, evidence of anything -- see below.
 
-    A SEPARATE dispatcher from `_dispatch_sdp` (133 D-01's frozen four-
+    A SEPARATE dispatcher from `_dispatch_sdp` (whose frozen four-
     positional forward contract, unchanged here): these four ops need a
     source payload, a read-back, and an `operation_flags` argument that
     signature cannot carry. Structurally clones `_dispatch_sdp`'s /
     `_dispatch_multi_run`'s guard -> branch -> terminal `raise
     AssertionError` shape rather than importing/reusing either.
 
-    ⚠ D-01 (measured, not merely designed around): the `0x86` opt-out ack
+    ⚠ Measured, not merely designed around: the `0x86` opt-out ack
     is UNOBSERVABLE from this module. `_operation_context`'s `finally`
     calls `_disconnect_programmer()` (`eprom_operations.py:405-416`), which
     sets `self.comm = None` before `write_eprom` returns, so
@@ -3248,14 +3246,15 @@ def _dispatch_sdp_leg(
     to `marginal`, naming both candidate causes (the
     opt-out not honoured by older firmware, or a transport fault).
 
-    ⚠ D-03's full 2x2 polarity proof holds for `OP_WRITE_INHIBITED`:
+    ⚠ The full 2x2 polarity proof holds for `OP_WRITE_INHIBITED`:
     `(True, A) -> OK`, `(True, B) -> BAD` -- these two hold the bool
     CONSTANT and vary only the read-back, a STRICTLY STRONGER proof than a
     bool-driven implementation could pass, because such an implementation
     cannot produce two different verdicts from one identical bool.
     `(False, A) -> marginal`, `(False, B) -> marginal` pin the precondition
     gate in both read-back directions. P-03 prevention 4's `(False, A) ->
-    OK` is OVERTURNED by D-01/D-03 and is deliberately NOT implemented here.
+    OK` is OVERTURNED by the two points above and is deliberately NOT
+    implemented here.
 
     ⚠ No sixth verdict status (research P-09/`ROADMAP` "no new verdict
     status"): `_verdict_code` (`cli_handlers.py`) is `.get(verdict, 0)`, so
@@ -3284,7 +3283,7 @@ def _dispatch_sdp_leg(
     # back B instead. FLAG_SKIP_SDP_UNLOCK is set on this op ONLY: setting
     # it on write-restored would defeat that step's whole purpose -- it
     # must be allowed to auto-unlock and succeed so the part is left
-    # writable (D-06's "restored" evidence).
+    # writable ("restored" evidence).
     if op == OP_WRITE_BASELINE_B:
         source_payload, expected_readback, flags = pattern_b, pattern_b, 0
     elif op == OP_WRITE_BASELINE_A:
@@ -3306,7 +3305,7 @@ def _dispatch_sdp_leg(
         raise AssertionError(f"unreachable: op {op!r} passed the _SDP_LEG_OPS guard")
 
     # Write, once (single-run: these ops are deliberately NOT _MULTI_RUN_OPS
-    # members, D-03).
+    # members).
     tmp_fh = tempfile.NamedTemporaryFile(
         prefix="chip_test_sdp_leg_", suffix=".bin", delete=False
     )
@@ -3394,7 +3393,7 @@ def _dispatch_sdp_leg(
         if wrote_ok and equal:
             verdict, reason = VERDICT_OK, ""
         elif wrote_ok and not equal:
-            # LEG-06, the leg's whole value -- covers both a full change to
+            # The leg's whole value -- covers both a full change to
             # B and a PARTIAL change (gh#11's exact symptom).
             verdict, reason = (
                 VERDICT_BAD,
@@ -3475,7 +3474,7 @@ def _dispatch_sdp_leg(
 #
 # DATA ONLY -- this module emits no print/render/CLI output; rendering the
 # "only N of M tests ran -- pass --destructive on a scrap chip for the rest"
-# banner belongs to Phase 110 (report model) / Phase 112 (dev test handler).
+# banner belongs to the report model and the dev test handler.
 #
 # Applicable-only counting (109-CONTEXT.md "Claude's Discretion", LOCKED by
 # 109-PATTERNS.md): M excludes NA/inapplicable slots (blank-check NA on
@@ -3514,7 +3513,7 @@ class BannerCounts:
 
 
 def count_applicable(plan: Plan, results: list[StepResult]) -> BannerCounts:
-    """Compute the SWEEP-05 applicable-only N-of-M banner data.
+    """Compute the applicable-only N-of-M banner data.
 
     M = `sum(1 for s in plan.steps if s.supported)` PLUS
     `len(plan.locked_destructive)` -- both read off the ONE `plan` object

--- a/firestarter/cli_handlers.py
+++ b/firestarter/cli_handlers.py
@@ -592,64 +592,28 @@ def write(
 ) -> None:
     """Writes a binary file to an EPROM.
 
-    TRAP #3 / D-13.3: ``--no-blank-check`` uses
-    ``is_flag=True, flag_value=False, default=True`` so the presence of ``-b``
-    flips ``blank_check`` to False (mirrors argparse ``store_false default=True``).
-    The inverse ``--blank-check`` polarity lives on the ``erase`` command —
-    both polarities coexist verbatim per the rationale lock.
+    \b
+    Blank check and erase are separate steps:
+      -b, --no-blank-check  skip the blank check only -- a pre-write erase
+                            still runs on electrically-erasable chips
+      --skip-erase          skip the pre-write erase as well
 
-    Phase 92 decouple: ``-b`` now skips ONLY the blank check. The pre-write erase
-    still runs for electrically-erasable chips (FLAG_CAN_ERASE) so ``write -b`` on
-    a non-blank flash/EEPROM works. Use ``--skip-erase`` to also skip the erase
-    (previously implied by ``-b``) for already-blank or non-erasable parts.
+    On protocols 0x0D and 0x05 the write path performs no pre-write blank
+    check at all, so -b is a no-op on those families and is not needed to
+    write a non-blank part. It remains effective on every other protocol.
 
-    Phase 153 (ERASE-01/ERASE-02): since this phase, ``-b``/``--no-blank-check``
-    is **unread** on protocols ``0x0D`` and ``0x05`` — neither protocol's write
-    path performs a pre-write blank check any more, so the flag is a no-op on
-    both families and is not needed to write a non-blank part on either one.
-    The flag remains live, with its Phase 92 meaning above, on every other
-    protocol. This does not change the paragraph above: the erase/blank-check
-    decoupling it describes still governs whichever protocols still read the
-    flag.
+    --skip-sdp-unlock applies to protocol-0x0D chips, where the firmware
+    unlocks software data protection during write init. On any other protocol
+    it has no effect and the write proceeds. The host may also set it on its
+    own when the resolved chip is protocol-0x0D and its protection state
+    cannot be read, and always reports when it does.
 
-    TRAP #6 / D-17/D-18 (v1.22 HOST-02): ``--skip-sdp-unlock`` is exposed
-    on ``write`` ONLY — firmware auto-unlocks in ``eeprom28c_write_init`` and
-    nowhere else, so ``read``/``verify``/``blank``/``erase`` have nothing to
-    skip and the flag is deliberately absent from all four (D-17). On a
-    non-protocol-0x0D chip the flag has no effect: firmware never reads this
-    bit outside protocol 0x0D, so the host warns and proceeds rather than
-    refusing or silently dropping the bit — the bit is still emitted so a
-    blanket-flag script across a mixed batch produces identical wire frames
-    (D-18). The host may also set this bit **on its own**, without the user
-    passing it, when the resolved chip is protocol-0x0D and capability-refused
-    (``firestarter.sdp_capability``) — see the D-04 auto-set block below,
-    which always prints a mandatory, default-visible report line when it
-    fires.
-
-    TRAP #7 / D-14..D-18 (v1.31 HOST-04/HOST-05): ``--pulse-us`` overrides
-    the database program-pulse width for this run only. D-14: it rides the
-    existing ``"pulse-delay"`` wire key (``write_eprom``'s own ``pulse_us``
-    parameter, plan 143-04's transport half) — no new command, no new wire
-    field. D-15: bounds are enforced by the option's own
-    ``click.IntRange(1, 65535)``, which refuses out of range at Click PARSE
-    TIME, exit 2. The guarantee this gives HOST-05 ("before any serial byte
-    is sent") is NOT "before ``AppContext`` builds" — ``cli()``'s group
-    callback runs first, before this command's own parameters are even
-    type-converted — the guarantee is that NOTHING in ``cli()`` or
-    ``AppContext`` construction opens a serial port, so a parse-time refusal
-    is still structurally before any serial byte. D-16: a value in
-    ``50001..65535`` is host-legal but firmware-refused on protocol ``0x0B``
-    only (``configure_eprom``'s ``energy_cap_us``-keyed pre-flight check,
-    ``MSG_ERR_PULSE_TOO_WIDE``) before any high voltage is enabled — the host
-    deliberately mirrors no table value to pre-empt it (that would require
-    duplicating ``energy_cap_us`` host-side). D-17: using the flag ALWAYS
-    prints a default-visible report line (see below) naming both the
-    database pulse replaced and the override — provenance, because a bench
-    artifact or log captured without the command line beside it cannot
-    otherwise tell you the pulse was not the database's. D-18: the flag
-    exists on ``write`` ONLY, mirroring the reasoning above for
-    ``--skip-sdp-unlock`` — ``read``/``verify``/``blank``/``erase`` emit no
-    program pulse, so there is nothing to override.
+    --pulse-us overrides the database program-pulse width for this run only,
+    in the range 1..65535 microseconds. Out-of-range values are refused before
+    the port is opened. A value above 50000 is refused by the firmware on
+    protocol 0x0B before any high voltage is enabled. Using the flag always
+    reports both the database pulse and the override, so a log captured
+    without its command line still records which pulse was used.
     """
     eprom_data = resolve_chip(eprom, db=app.db)
 
@@ -860,21 +824,14 @@ def erase(
 ) -> None:
     """Erase an EPROM, if supported.
 
-    TRAP #3 / D-13.3: this command keeps the inverse ``--blank-check`` polarity
-    (``is_flag=True default=False``) — opposite of ``write``'s
-    ``--no-blank-check``. Both polarities coexist verbatim from argparse.
+    ``-b``/``--blank-check`` requests a blank check performed **after** the erase.
+    Note the inverted sense against ``write``, whose ``-b``/``--no-blank-check``
+    skips a check performed before it. On protocol ``0x0D`` the post-erase check is
+    not wired, so ``-b`` has no effect there.
 
-    D-153-04: unlike ``write``'s ``-b``, this command's ``-b``/``--blank-check``
-    requests a blank check performed **after** the erase, not skipped before it
-    — the inverse polarity above is a naming/default inversion, not just a
-    default flip. On protocol ``0x0D`` this post-erase check is not wired (no
-    ``operation_end`` arm was added to the software chip-erase handler), so
-    ``-b`` is a documented no-op there, not a discovered one.
-
-    D-153-04 (RESEARCH A7): ``-s``/``--sector-address`` exists for the
-    ``0x06`` sector-erase protocol. The ``0x0D`` software chip erase is
-    device-global by construction (the whole part is erased in one AN 0544B
-    sequence) and ignores any sector address given for it.
+    ``-s``/``--sector-address`` applies to the ``0x06`` sector-erase protocol. The
+    ``0x0D`` software chip erase is device-global by construction and ignores any
+    sector address given for it.
     """
     eprom_data = resolve_chip(eprom, db=app.db)
     ok = app.eprom_operator.erase_eprom(
@@ -1141,14 +1098,8 @@ def fw(
 ) -> None:
     """Firmware version.
 
-    Implements TRAP #4 (3-way --pre / --firmware-version / --stable mutex via
-    a single post-parse check at the top of the command body — WR-03; replaces
-    the earlier per-option callback _check_install_mutex which depended on
-    Click's left-to-right option-processing order) and TRAP #5 (firmware-version
-    validator via custom Click ParamType _FirmwareVersionType). D-14 narrow
-    upgrade: the post-parse `--json requires --list` check uses
-    `raise click.UsageError(...)` (exit-2 + "Usage:" formatting preserved
-    from the argparse `fw_parser.error()` form).
+    ``--pre``, ``--firmware-version`` and ``--stable`` are mutually exclusive;
+    passing more than one is refused before anything is installed.
     """
     app: AppContext = ctx.obj
 
@@ -1175,7 +1126,7 @@ def fw(
     if json_output and not list_releases:
         raise click.UsageError("--json requires --list")
 
-    # HOST-02 / D-08: both py32-only options are refused through one shared
+    # both py32-only options are refused through one shared
     # helper, called unconditionally for each option with its givenness,
     # before either option is consumed below. `hidden=not _PY32_ENABLED` on
     # both option declarations (above) keeps them out of --help; it does not
@@ -1498,7 +1449,7 @@ if _DEV_TOOLS_ENABLED:
         "-q",
         "--quiet",
         is_flag=True,
-        help="Suppress per-run tqdm progress bars (D-11).",
+        help="Suppress per-run tqdm progress bars.",
     )
     @click.option(
         "-f",
@@ -1536,12 +1487,8 @@ if _DEV_TOOLS_ENABLED:
     ) -> None:
         """Read EPROM N consecutive times and report SHA-256 divergence.
 
-        D-12 step 5 / 3-way verdict contract:
-            verdict_int = consistency_check_eprom(...)  # 0=PASS, 1=FAIL, 2=hw-error
-            sys.exit(verdict_int)  # NOT bool-to-int wrap
-
-        The bool-to-int wrap would collapse the 2=hardware-error case to 1=FAIL,
-        breaking the v1.6 RCA diagnostic.
+        Exits 0 on PASS, 1 on FAIL, 2 on hardware error. The three are distinct: a
+        hardware error is not reported as a failed comparison.
         """
         eprom_data = resolve_chip(eprom, db=app.db)
         verdict_int = app.eprom_operator.consistency_check_eprom(
@@ -1593,14 +1540,10 @@ if _DEV_TOOLS_ENABLED:
         output_dir: Optional[str],
         force: bool,
     ) -> None:
-        """Erase → write source image → read-back N times; assert SHA-256 == source SHA.
+        """Erase, write the source image, read back N times, and compare SHA-256.
 
-        3-way verdict contract (mirrors dev consistency-check):
-            verdict_int = write_cycle_eprom(...)  # 0=PASS, 1=mismatch, 2=hw-error
-            sys.exit(verdict_int)  # NOT bool-to-int wrap — preserves 0/1/2
-
-        The bool-to-int wrap would collapse the 2=hardware-error case to 1=mismatch,
-        breaking the v1.6 RCA diagnostic. XACT-01 / Phase 53 Plan 02.
+        Exits 0 on PASS, 1 on mismatch, 2 on hardware error. The three are distinct: a
+        hardware error is not reported as a mismatch.
         """
         eprom_data = resolve_chip(eprom, db=app.db)
         verdict_int = app.eprom_operator.write_cycle_eprom(
@@ -1657,12 +1600,13 @@ if _DEV_TOOLS_ENABLED:
     ) -> None:
         """Demonstrate COBS resync: inject a corrupted frame and assert recovery on the next.
 
-        cycle mode: one corrupted transfer then asserts the same connection recovers on a
-        clean follow-on transfer (XACT-02 / Phase 53 Plan 02).
+        cycle mode runs one corrupted transfer, then asserts the same connection
+        recovers on a clean follow-on transfer.
 
-        latency mode: opens ONE pinned port and times the firmware's per-frame NAK on a
-        corrupt CMD_FW_VERSION frame (established connection — avoids the multi-port
-        connect-retry that inflates cycle-mode's outgoing latency). Use with -p <port>.
+        latency mode opens one pinned port and times the firmware's per-frame NAK on a
+        corrupt CMD_FW_VERSION frame. Use it with ``-p <port>``; an already-established
+        connection avoids the multi-port connect-retry that inflates cycle mode's
+        outgoing latency.
         """
         if mode == "latency":
             ok = app.eprom_operator.measure_command_nak_latency(
@@ -1698,7 +1642,7 @@ if _DEV_TOOLS_ENABLED:
         "--force",
         is_flag=True,
         help=(
-            "Proceed past a table refusal anyway (D-07). The result is an "
+            "Proceed past a table refusal anyway. The result is an "
             "unadjudicated probe, never a state claim -- and this never sets "
             "a wire-visible flag (C-16): the table refusal it bypasses is a "
             "host-side decision only."
@@ -1707,7 +1651,7 @@ if _DEV_TOOLS_ENABLED:
     @click.pass_obj
     @map_typed_errors
     def dev_lock_status(app: AppContext, eprom: str, force: bool) -> None:
-        """Diagnostic read of a chip's write-protection state -- not a guarantee (D-01)."""
+        """Diagnostic read of a chip's write-protection state -- not a guarantee."""
         # Resolve through db.get_eprom(), never resolve_chip()'s
         # programmer dict -- that dict carries neither 'protocol-id' nor
         # 'name', the exact shape protection_gate_for_entry hard-fails on.
@@ -1963,23 +1907,19 @@ if _DEV_TOOLS_ENABLED:
         source: Optional[str],
         output_dir: Optional[str],
     ) -> None:
-        """Run the per-family validation matrix Tier-3 runner (HARN-01 / D-05).
+        """Run the per-family validation matrix Tier-3 runner.
 
-        Composes write_cycle_eprom / consistency_check_eprom (no re-implementation).
-        Emits validation-matrix.{json,md} results artifact (D-02).
+        Emits a validation-matrix.{json,md} results artifact.
 
-        SKIP-deferred path (D-06): when no board/chip/source is available, records
-        all Tier-3 cells as SKIP-deferred and exits 0 — milestone stays closeable
-        at partial bench coverage.
+        Exits 0 on PASS, 1 on FAIL, 2 on hardware error.
 
-        3-way verdict contract (mirrors dev write-cycle + consistency-check):
-            0 = PASS  1 = FAIL  2 = hw-error
+        When no board, chip or source image is available, every Tier-3 cell is recorded
+        as SKIP-deferred and the command exits 0.
 
-        Non-vacuous oracle (HARN-03 / D-08):
-        - Leonardo is the only authoritative PASS board; other boards are advisory.
-        - uno328pb write/program cells are hard N/A (brownout 999.2).
-        - r1 ≈ 270000 ±25% precondition aborts before any write cycle.
-        - retry_count is captured into each cell.
+        Reading the results: Leonardo is the only authoritative PASS board and others
+        are advisory; uno328pb write and program cells are hard N/A; an r1 outside
+        270000 ohms +/-25% aborts before any write cycle; retry_count is captured into
+        each cell.
         """
         spec = _load_validation_spec()
         families = _families_for_selection(family, spec)
@@ -2411,7 +2351,7 @@ def dev_test(app: "AppContext", chip: str, fast: bool) -> None:
     chip-ID mismatch). The write/verify block runs as a CYCLE, twice, and the
     cycles are compared -- a rig-health check for rail droop or bad contact.
     """
-    # SAFE-04: hard-fail BEFORE any hardware is energized when the chip name
+    # hard-fail BEFORE any hardware is energized when the chip name
     # is absent from the DB entirely (case A). Keyed strictly off
     # `get_eprom` emptiness -- NEVER a `resolve_chip` support-status refusal
     # -- so an in-DB-but-unsupported chip (case B, e.g. adapter-required)
@@ -2471,7 +2411,7 @@ def dev_test(app: "AppContext", chip: str, fast: bool) -> None:
     )
     report.results = results
     report.banner = count_applicable(plan, results)
-    # LEG-12: the derive-in-engine / assign-in-handler seam. `sdp_hold_state`
+    # the derive-in-engine / assign-in-handler seam. `sdp_hold_state`
     # is computed in chip_test.py (the engine); this line only ASSIGNS it,
     # matching every other derived field above and below (never computed
     # inline here).

--- a/firestarter/cli_handlers.py
+++ b/firestarter/cli_handlers.py
@@ -474,7 +474,7 @@ def search(app: AppContext, text: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Chip-op commands (Wave 3 / Plan 41-03 / D-12 step 1; Plan 42-02 / D-03/D-05)
+# Chip-op commands
 # Each: resolve chip via resolve_chip(eprom, db=app.db) → call
 # app.eprom_operator.<op> → sys.exit(0 if ok else 1). The @map_typed_errors
 # decorator catches ChipNotFoundError at the Click boundary and re-raises as
@@ -885,7 +885,7 @@ def chip_id(app: AppContext, eprom: str, force: bool) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Voltage commands (Wave 3 / D-12 step 2)
+# Voltage commands
 # ---------------------------------------------------------------------------
 
 
@@ -914,7 +914,7 @@ def vpe(app: AppContext, timeout: Optional[int]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Hardware commands (Wave 3 / D-12 step 3)
+# Hardware commands
 # ---------------------------------------------------------------------------
 
 
@@ -970,11 +970,11 @@ def config(
 
 
 # ---------------------------------------------------------------------------
-# Firmware command (Wave 3 / D-12 step 4)
-# TRAPs #4 (3-way mutex enforced post-parse at top of fw() body — WR-03;
+# Firmware command
+# The 3-way mutex is enforced post-parse at the top of fw()'s body;
 # previously per-option callback _check_install_mutex, now removed)
-# + #5 (_FirmwareVersionType custom ParamType). D-14 (UsageError on --json
-# without --list). D-15 (SimpleNamespace adapter for _maybe_auto_route_to_pre).
+# _FirmwareVersionType is a custom ParamType. UsageError on --json
+# without --list. SimpleNamespace adapter for _maybe_auto_route_to_pre.
 # ---------------------------------------------------------------------------
 
 
@@ -983,10 +983,10 @@ def _maybe_auto_route_to_pre_click(
 ) -> bool:
     """Click-side equivalent of the _maybe_auto_route_to_pre helper.
 
-    D-15 picks the SimpleNamespace adapter approach: build a namespace from
+    Builds a namespace from
     the relevant fw kwargs, hand it to the (now-local) helper. Keeps the
     helper's body untouched (zero churn; relocated from main.py in Wave 4 /
-    Plan 41-04 per D-16).
+    the CLI's own values).
 
     Returns the (possibly-overridden) pre value so the caller can use it
     for channel resolution.
@@ -1254,7 +1254,7 @@ class _DevGroup(click.Group):
 
 
 # ---------------------------------------------------------------------------
-# dev group + 4 sub-commands (Wave 3 / D-12 step 5)
+# dev group + 4 sub-commands
 # ---------------------------------------------------------------------------
 
 
@@ -1713,7 +1713,7 @@ if _DEV_TOOLS_ENABLED:
 
 
 # ---------------------------------------------------------------------------
-# dev validate-family (71-06 / HARN-01 Tier-3 + HARN-02 + HARN-03)
+# dev validate-family (Tier-3 runner)
 # ---------------------------------------------------------------------------
 
 # r1 calibration tolerance band: 270000 ± 25%
@@ -1756,7 +1756,7 @@ def _emit_skip_deferred_artifact(
 ) -> None:
     """Emit validation-matrix.{json,md} with all Tier-3 cells as SKIP-deferred.
 
-    D-06: milestone remains closeable at partial bench coverage.
+    A milestone remains closeable at partial bench coverage.
     Artifact name is validation-matrix.{json,md} (hyphen, NEVER underscore).
     """
     cells: List[Dict[str, Any]] = []  # noqa: UP006
@@ -1801,7 +1801,7 @@ def _write_artifact(
     """Write validation-matrix.json and validation-matrix.md to output_dir.
 
     Artifact name uses hyphens (distinct from authored validation_matrix_spec.json
-    — Pitfall 4 / D-02).
+    ).
     """
     out_path = Path(output_dir) if output_dir else Path(".")
     out_path.mkdir(parents=True, exist_ok=True)
@@ -1955,8 +1955,8 @@ if _DEV_TOOLS_ENABLED:
 
         # r1 precondition: abort before any cycle if r1 is out of band.
         # The r1 value is read from hardware config via the HardwareManager.
-        # In Phase 71 (software scaffold), the hardware path is exercised only
-        # in Phase 73 with real hardware; here we gate on the operator config.
+        # The hardware path is exercised only with real hardware; here we gate
+        # on the operator config.
         r1_raw: Optional[int] = None
         try:
             hw_config = app.config_manager.get_value("r1", None)
@@ -1975,7 +1975,7 @@ if _DEV_TOOLS_ENABLED:
             )
             sys.exit(2)
 
-        # Compose cycle methods for each family (D-10 reuse-not-reimpl).
+        # Compose cycle methods for each family -- reuse, not reimplement.
         hw_cells: List[Dict[str, Any]] = []  # noqa: UP006
         overall_verdict = 0
 
@@ -1989,7 +1989,7 @@ if _DEV_TOOLS_ENABLED:
 
             eprom_data = resolve_chip(rep_chip, db=app.db)
 
-            # Compose write_cycle_eprom (D-10: no re-implementation of write+readback).
+            # Compose write_cycle_eprom -- no re-implementation of write+readback.
             verdict_int = app.eprom_operator.write_cycle_eprom(
                 rep_chip,
                 eprom_data,
@@ -2158,7 +2158,7 @@ def _chip_id_fields(
     `chip_id_expected` is read directly off the DB entry (host-side, never
     from firmware). `chip_id_actual`/`chip_id_mismatch_reason` are recovered
     from the id step's `StepResult.reason` text (the ONLY place
-    `chip_test._dispatch_id` records the detected id, RPT-02) when a mismatch
+    `chip_test._dispatch_id` records the detected id) when a mismatch
     was reported; on a clean/NA/SKIPPED id step there is no actual-id
     disagreement to surface, so both stay `None`.
     """
@@ -2194,14 +2194,14 @@ def _is_interactive() -> bool:
 def _make_sampler(app: "AppContext", report: DiagnosticReport) -> Any:
     """Build the before/after sampler thunk closing over `hardware_manager`.
 
-    Constructed on EVERY run (Phase 121 D-04: `dev test` always writes, so
+    Constructed on EVERY run (`dev test` always writes, so
     there is no non-destructive mode left to distinguish this from -- the
     `--destructive`-only construction this docstring used to describe was
     superseded when that flag was deleted). Reuses the existing
     `sample_vpp_mv`/`sample_vpe_mv` monitor path (COMMAND_READ_VPP/VPE,
-    energize+measure only -- SAFE-02) -- no VPP-set call is made here or
+    energize+measure only) -- no VPP-set call is made here or
     anywhere in this module. `chip_test.run_plan` calls this as an opaque
-    `sampler(phase)` callable and never imports `hardware.py` itself (D-04
+    `sampler(phase)` callable and never imports `hardware.py` itself (
     decoupling, chip_test.py:542-553).
     """
 
@@ -2312,12 +2312,12 @@ _ALWAYS_WRITES_PASS_COUNT = 6
 # `FIRESTARTER_CONFIG_DIR`) and is always handed to `submit_report`
 # (DEVTEST-05/06; Plan 121-11 owns that function's internals).
 #
-# REVERSAL (Phase 121 D-01/D-03/D-04/D-05, operator-specified
+# REVERSAL (operator-specified
 # 2026-07-29): this supersedes v1.21's non-destructive-by-default premise
-# entirely, SAFE-01's CLI-only `--destructive` flag (removed, not merely
-# disabled), and SAFE-03's statement that the destructive confirm was
+# entirely, the CLI-only `--destructive` flag (removed, not merely
+# disabled), and the earlier statement that the destructive confirm was
 # "the ONLY interactive input left in this handler" (superseded by the
-# UV-only ask above). Phase 112 Plan 04's deliberate removal of every
+# UV-only ask above). The deliberate removal of every
 # interactive prompt about tester-supplied identity is PARTIALLY reversed
 # in spirit by that same UV ask -- it is a new interactive prompt, just
 # not an identity-collection one; shield revision, chip origin and
@@ -2359,7 +2359,7 @@ def dev_test(app: "AppContext", chip: str, fast: bool) -> None:
     if not app.db.get_eprom(chip):
         raise ChipNotFoundError(f"{chip}: not found in database")
 
-    # The chip must be known to be in the DB (SAFE-04 above) before its
+    # The chip must be known to be in the DB (see above) before its
     # electrical type can be read, so the UV-scope resolution happens here,
     # after the hard-fail.
     interactive = _is_interactive()

--- a/firestarter/codec.py
+++ b/firestarter/codec.py
@@ -62,7 +62,7 @@ def format_message(msg_id: int, params: List[Any], entry: MessageDef) -> Optiona
     Returns the rendered string for sentinel-byte IDs where the catalog
     format string cannot express the conditional (0xFF = no override),
     and for the silkscreen-aware INFO surfaces that share the same
-    revision byte as MSG_OK_REV (Phase 35 D-03 / D-04 — close WR-01 + WR-02).
+    revision byte as MSG_OK_REV.
 
     Returns None for all other IDs (caller falls through to generic rendering).
 
@@ -73,19 +73,19 @@ def format_message(msg_id: int, params: List[Any], entry: MessageDef) -> Optiona
     P-03 MSG_OK_CFG  — params[0]=r1 u32, params[1]=r2 u32, params[2]=override u8
       override==0xFF → "R1: {r1}, R2: {r2}"
       override!=0xFF → "R1: {r1}, R2: {r2}, Override HW: {silkscreen_str}"
-      Phase 35 D-04 / WR-02 close: override clause now routes through
+      Override clause now routes through
       _REVISION_SILKSCREEN so the same byte that surfaces as "Rev 2.0-class"
       via MSG_OK_REV no longer surfaces as "Rev2" on the adjacent ack line.
 
     MSG_INFO_HW (0x5B) — single u8 revision byte; renders
       "HW: {silkscreen_str}" via _REVISION_SILKSCREEN.get(byte, "Rev{byte}").
-      Phase 35 D-03 / WR-01 close: was rendering catalog-default
+      Was rendering catalog-default
       "HW: Rev%u" (e.g. "HW: Rev254" for REVISION_UNKNOWN=0xFE) — directly
-      contradicting Phase 34 D-09 (host displays silkscreen strings; wire
+      contradicting the rule that the host displays silkscreen strings while the wire
       carries raw byte).
 
     MSG_INFO_PHYSICAL_HW (0x5C) — same shape as MSG_INFO_HW with the
-      "Physical HW: " prefix. Phase 35 D-03 / WR-01 close.
+      "Physical HW: " prefix.
     """
     if msg_id == MSG_OK_REV and len(params) == 2:
         physical, effective = params[0], params[1]
@@ -171,13 +171,13 @@ def format_message(msg_id: int, params: List[Any], entry: MessageDef) -> Optiona
 def decode_id_frame(frame_len: int, body: bytes) -> Optional[LogMessage]:
     """
     Read-path-adjacent — behavior preserved verbatim from serial_comm.py per
-    GATE-1.8d. Do not refactor without re-validating Phase 26 baseline binaries.
+    Ring-fenced. Do not refactor without re-validating the v1.6 baseline binaries.
 
     Decode an ID-encoded wire frame body (the bytes between the length
     byte and the trailing 0x0A re-sync anchor).
 
     `body` carries `id | params | crc` exactly `frame_len` bytes long
-    (length is authoritative per CONTEXT §D-03; CRC8 covers `[id, params]`
+    (length is authoritative; CRC8 covers `[id, params]`
     but not the length byte nor the terminator).
 
     Returns a LogMessage on success. Returns None (with a `logger.warning`)

--- a/firestarter/constants.py
+++ b/firestarter/constants.py
@@ -39,11 +39,11 @@ MAX_DATA_CHUNK = BUFFER_SIZE - 2  # 510
 # per CLAUDE.md constant-parity rule.
 CMD_FRAME_MAX = 512
 
-# IN-02 (Phase 98-03/98-05): <=256K (262144 byte) size boundary for 0x08
+# <=256K (262144 byte) size boundary for 0x08
 # (EPROM_QUICK) 32-pin parts where pin 31 (A18 on DIP32_STD) is structurally
 # unused as an address line and is safe to repurpose as DIP32_27C020's
 # PGM/RW strobe. Chips above this boundary (512K AM27C040, 1M AM27C080)
-# legitimately use pin 31 = A18 and MUST stay on DIP32_STD (D-04 alias guard).
+# legitimately use pin 31 = A18 and MUST stay on DIP32_STD (alias guard).
 # tools/build_db.py imports this constant (single host-side source of truth)
 # rather than redefining it. Firmware parity: firestarter.h #define
 # MAX_27C020_SIZE 262144 — a divergence is a hardware-damage A18 risk;
@@ -150,11 +150,11 @@ JSON_KEY_READ_SETTLING_DELAY = "read-settling-delay"
 JSON_KEY_READ_STROBE_US = "read-strobe-us"
 # Per-chip page size wire field. Emitted by database.py's
 # convert_to_programmer only when the DB supplies a page_size (curated or,
-# as of Phase 149, provenance-keyed for upstream-native 0x0D rows) --
+# provenance-keyed for upstream-native 0x0D rows) --
 # emit-when-present, mirrors the chip-id pattern. When absent, firmware
 # falls back to its own named AT28C page-size floor constant (algorithm 13
 # / 0x0D only; other algorithms' handlers do not consume this key at all).
-# Firmware sync: json_parser.c (key_page_size). Landed by Phase 149 plan 04
+# Firmware sync: json_parser.c (key_page_size).
 # (firestarter commit 58c6a3c) -- the PROGMEM string exists and is dispatched
 # from key_parsers[]. tests/test_json_key_parity.py (plan 05) is the
 # enforcing test that keeps this string in lockstep with the firmware key.

--- a/firestarter/database.py
+++ b/firestarter/database.py
@@ -336,7 +336,7 @@ class EpromDatabase:
     def map_chip_record(self, ic: dict, manufacturer: str) -> dict:
         """Public alias for `_map_data` — stable surface for callers outside this module.
 
-        Phase 41 / WR-05: the `id` command in cli_handlers.py previously reached into
+        The `id` command in cli_handlers.py previously reached into
         `db._map_data` directly to render `search_chip_id` results. That coupled the CLI
         to a private name; this thin wrapper decouples the surface without changing
         behaviour. Future refactors can rework `_map_data`'s signature freely as long
@@ -400,7 +400,7 @@ class EpromDatabase:
 
         # PGSZ-01 / CR-01: carry per-chip page_size when present. Set by
         # build_db.py either for a datasheet-curated [CITED:] chip or, as
-        # of Phase 149, for a chip whose OWN upstream protocol_id is 0x0D
+        # for a chip whose OWN upstream protocol_id is 0x0D
         # (algorithm 13 / EEPROM_POLL only). This guard is a TRUTHINESS
         # test (`if page_size_val:`), not a presence test -- a page_size of
         # 0 is therefore silently dropped and unreachable on the wire from
@@ -543,7 +543,7 @@ class EpromDatabase:
             programmer_data["bus-config"] = full_eprom_data["bus-config"]
 
         # PGSZ-03 / CR-01: emit page-size wire field only when the DB supplies a
-        # page_size (curated or, as of Phase 149, provenance-keyed for an
+        # page_size (curated or provenance-keyed for an
         # upstream-native 0x0D row) -- emit-when-present, mirrors chip-id.
         # This guard is also a TRUTHINESS test (`.get(...)` is truthy-checked,
         # not `"page_size" in full_eprom_data`), so a page_size of 0 is

--- a/firestarter/diagnostic_report.py
+++ b/firestarter/diagnostic_report.py
@@ -67,7 +67,7 @@ class AutoCapture:
     """Auto-captured identity/protocol fields -- no tester input.
 
     `fw_board_identity` is `str | None` because it is RECEIVED as threaded-in
-    input from Phase 112 (which captures `version:board` off the transient
+    input from the dev test handler (which captures `version:board` off the transient
     per-operation `comm.programmer_info`, when an orchestrator-safe live
     source is reachable) -- this dataclass and this module NEVER fetch it
     themselves and NEVER import the serial-transport class (Pitfall 1).
@@ -77,8 +77,8 @@ class AutoCapture:
 
     `hw_revision` is `str | None` -- the coarse silkscreen-bucket string the
     firmware/codec produce (e.g. a "Rev 2.0-class"-style label), or `None`
-    when not measured. It is ALWAYS auto-captured (Phase 112 Plan 04 reverses
-    the earlier D-05 "always human-asked" precision argument) -- this
+    when not measured. It is ALWAYS auto-captured (reversing an earlier
+    "always human-asked" precision argument) -- this
     dataclass and this module never prompt a human for it, and a coarse or
     absent reading is an accepted, honest outcome rather than a gap.
     """
@@ -120,7 +120,7 @@ class TransportHealth:
 def _is_transport_suspect(th: TransportHealth) -> bool:
     """True only when a counter is PRESENT (not None) AND elevated.
 
-    Absent counters can never fabricate suspicion -- mirrors Phase 108's
+    Absent counters can never fabricate suspicion -- mirrors the
     honest `indeterminate` fingerprint bucket. Since no counter is reachable
     today (RESEARCH §Transport Counter Survey), this always returns False in
     production; it exists so a future counter source activates it without a
@@ -136,7 +136,7 @@ def _is_transport_suspect(th: TransportHealth) -> bool:
 # Submittability -- auto-capture-only, no human gate
 # ---------------------------------------------------------------------------
 #
-# REVERSAL: this section previously held the RPT-04 / D-04/D-05/D-06
+# REVERSAL: this section previously held the
 # interactive tester-input-collection model -- a collector function, a
 # human-input dataclass, and enumerated choice-list constants for shield
 # revision and chip origin. All deleted (operator-approved, 112-UAT.md test
@@ -232,7 +232,7 @@ def dedup_fingerprint(report: DiagnosticReport) -> str:
     # 260822-aq6 applied to `repeat_policy_tag` above ("returns `""` for
     # the default policy and the append is skipped entirely... no
     # historical group is re-keyed"), and the deliberate difference from
-    # v1.30 D-11, which accepted a full re-key.
+    # an accepted full re-key.
     coverage = coverage_tag(report.results)
     if coverage:
         parts.append(coverage)
@@ -330,7 +330,7 @@ def build_db_diff(name: str, db: Any, results: list[StepResult]) -> DbDiff:
 def _identity_cell(value: object) -> str:
     """Render-only substitution for an absent identity value. Used ONLY inside
     `render()` -- never in `to_dict()`, which is
-    where the `NOT_MEASURED` precedent substitutes and where D-10 requires
+    where the `NOT_MEASURED` precedent substitutes and where the contract requires
     the fenced report JSON to keep typed `null` (machine consumers keep
     testing `is None`, so PROV-04's backward-compatibility story stays ONE
     case instead of two).
@@ -367,7 +367,7 @@ def _hex_cell(value: object, digits: int) -> str:
     `TypeError`, never a bare `Exception`). This deliberately does NOT
     reuse `_identity_cell`'s absent-value marker: a live gate
     (test_absent_identity_renders_the_explicit_marker_in_both_rows) asserts
-    `NOT_REPORTED` appears exactly twice in the whole table, and D-12
+    `NOT_REPORTED` appears exactly twice in the whole table, and the
     already records that the chip-ID row legitimately renders `None`/`None`
     on a minimal report -- rendering `NOT_REPORTED` here would both break
     that count and contradict that recorded rationale. The operator asked
@@ -402,7 +402,7 @@ def _rail_cell(before: object, after: object) -> str:
 
     Renders only the bracketed pair. The `vpp_mv`/`vpe_mv` standalone
     slots are deliberately NOT shown: they exist for a non-destructive
-    reading, and since D-04 made every run destructive (the sampler is
+    reading, and since every run is destructive (the sampler is
     always built) NOTHING in the code path assigns them, so they printed
     `not measured` on every single run beside real bracket numbers. They
     stay in `to_dict()` -- this only stops the box repeating two dead
@@ -577,7 +577,7 @@ class DiagnosticReport:
     # is read as ground truth for a protection state this chip family
     # cannot report at all). Defaults to `""` (unassigned); the VALUE is
     # assigned by `cli_handlers.py` from `chip_test.sdp_hold_state(plan,
-    # results)` in plan 134-07, which closes LEG-12 -- this class only
+    # results)` -- this class only
     # carries and serialises whatever string it is given, never derives one
     # (this is a declared non-registry, re-measured every run by
     # `test_non_registry_still_has_no_ops`'s AST inversion guard to carry
@@ -642,7 +642,7 @@ class DiagnosticReport:
     def _write_step_index(self) -> int | None:
         """Structurally locate the shipped write/write-partial step's
         index in `self.plan.steps` -- NEVER by comparing against a
-        specific `OP_*` constant (LEG-15, `tests/test_op_registration_
+        specific `OP_*` constant (`tests/test_op_registration_
         parity.py::test_non_registry_still_has_no_ops`; this class is a
         declared op-vocabulary non-registry, re-measured every run by an
         AST walk over this class's body).
@@ -692,7 +692,7 @@ class DiagnosticReport:
             "verdict": result.verdict,
             # Schema 1.7: how many times the
             # underlying operator method actually ran for this step. It has
-            # been 2 for every read/write/verify/erase since Phase 121's
+            # been 2 for every read/write/verify/erase since the
             # N>=2 repeat policy and 1 for the ops that are
             # single-run by design -- but the number reached NO consumer
             # outside the test suite, so an operator watching `read, read,
@@ -701,7 +701,7 @@ class DiagnosticReport:
             # disclosure surface, and a `--fast` run's `1` is what makes the
             # weaker policy legible instead of silent.
             "run_count": result.run_count,
-            # Quick task 260822-gxx (operator reversal of this plan's D-2):
+            # Operator reversal of an earlier decision:
             # an NA-verdict step reports NO reason anywhere, including this
             # export dict -- and therefore in both the saved
             # `dev-test-<chip>.json` and the fenced JSON block inside the
@@ -815,7 +815,7 @@ class DiagnosticReport:
 
         Quick task 260822-aq6 added ONE cell back to each step row: the
         step's own `run_count` as `xN` (`_runs_cell`), between the verdict
-        and the duration. It is the smallest thing that makes Phase 121's
+        and the duration. It is the smallest thing that makes the
         N>=2 repeat policy legible at the point an operator actually
         notices it -- watching the same op go past twice.
         """
@@ -856,7 +856,7 @@ class DiagnosticReport:
         #
         # Safe to hide: `NA` and `SKIPPED` both map to exit code 0
         # (`cli_handlers._VERDICT_EXIT_CODES`), so no nonzero-exit cause can
-        # hide here. The one non-verdict exit term, D-15's not-run SDP
+        # hide here. The one non-verdict exit term, the not-run SDP
         # oracle floor, stays legible in the `sdp_hold_state` row above.
         # Every step keeps its full entry in `to_dict()["steps"]`, so the
         # JSON, the markdown table and the filed issue body are unchanged.
@@ -910,7 +910,7 @@ class DiagnosticReport:
         #
         # Read straight off `d["steps"]` -- `write_coverage` was already
         # computed once, in `to_dict()`/`_step_dict()`, off the located
-        # write step's OWN row (`_write_step_index`, LEG-15-compliant:
+        # write step's OWN row (`_write_step_index`:
         # never a specific-`OP_*` comparison inside this class). Never a
         # second computation here, and never a re-parse of the JSON string
         # -- single-sourced, same discipline every other render() row uses.

--- a/firestarter/diagnostic_report.py
+++ b/firestarter/diagnostic_report.py
@@ -265,9 +265,8 @@ _LADDER_NONE = ""
 
 @dataclass
 class DbDiff:
-    """Current DB `support_status` beside an ADVISORY proposed-disposition
-    (RPT-05, D-07) plus a derived report-side `ladder_state` tag (GRAD-01,
-    D-01/D-02).
+    """Current DB `support_status` beside an ADVISORY proposed-disposition plus
+    a derived report-side `ladder_state` tag.
 
     `proposed_disposition` is always plainly-labeled descriptive triage
     text -- it is NEVER a concrete `support_status` value and this module
@@ -329,8 +328,8 @@ def build_db_diff(name: str, db: Any, results: list[StepResult]) -> DbDiff:
 
 
 def _identity_cell(value: object) -> str:
-    """Render-only substitution for an absent identity value (D-10, D-11,
-    D-12). Used ONLY inside `render()` -- never in `to_dict()`, which is
+    """Render-only substitution for an absent identity value. Used ONLY inside
+    `render()` -- never in `to_dict()`, which is
     where the `NOT_MEASURED` precedent substitutes and where D-10 requires
     the fenced report JSON to keep typed `null` (machine consumers keep
     testing `is None`, so PROV-04's backward-compatibility story stays ONE
@@ -572,7 +571,7 @@ class DiagnosticReport:
     vpp_mv: int | None = None
     vpe_mv: int | None = None
     db_diff: DbDiff | None = None
-    # LEG-12: the carriage half only --
+    # the carriage half only --
     # a plain `str`, NEVER a `bool` and NEVER a key named `locked` or
     # `protection_enabled` (P-06 prevention 3: a JSON `true` on such a key
     # is read as ground truth for a protection state this chip family
@@ -791,8 +790,8 @@ class DiagnosticReport:
         }
 
     def render(self, console: Any = None) -> Any:
-        """Human `rich` table built from the SAME dict `to_dict()` produces
-        (RPT-01, D-01) -- never a second hand-maintained field list, never a
+        """Human `rich` table built from the SAME dict `to_dict()` produces --
+        never a second hand-maintained field list, never a
         re-parse of the JSON string produced by `to_json_block()`.
 
         Quick task 260821-spg trimmed this table to what a tester actually
@@ -894,7 +893,7 @@ class DiagnosticReport:
         if total:
             table.add_row("steps total", _duration_cell(total))
 
-        # LEG-12: its own console row, never folded into a step's `reason`.
+        # its own console row, never folded into a step's `reason`.
         # Rendered via `_state_cell` -- a no-op passthrough today, since
         # quick task 260822-hs stripped the NOT-RUN reason at its source
         # (`chip_test.sdp_hold_state()`); see `_state_cell`'s own docstring

--- a/firestarter/eprom_info.py
+++ b/firestarter/eprom_info.py
@@ -118,7 +118,7 @@ class EpromConsolePresenter:
             return None
 
         # Get base specifications from EpromSpecBuilder.
-        # Pass electrical_type from the raw config so D-01/D-02 use ground-truth.
+        # Pass electrical_type from the raw config so both use ground-truth.
         electrical_type = None
         if raw_config_data:
             electrical_type = raw_config_data.get("electrical", {}).get("type") or None
@@ -343,13 +343,13 @@ class EpromConsolePresenter:
 def print_eprom_list_table(eproms_data: list, spec_builder: EpromSpecBuilder):
     """Prints a list of EPROM data in a table format. For CLI/testing.
 
-    Column layout (D-01, D-02, D-03, D-04 — Phase 61):
+    Column layout:
     - Name: dynamic width clamped to [13, 20]; names longer than 20 chars are
       truncated with a trailing ellipsis ('…') that counts toward the 20-char cap.
     - Manufacturer: fixed 17; Pins: fixed 5; Chip ID: fixed 11; Type: fixed 12.
     - VPP: fixed 5 (every voltage string is 5 chars; '-' padded to 5).
     - Type is sourced from electrical-type via spec_builder.resolve_type_label.
-    - VPP shown only when vpp_mv > 0 AND electrical-type != 'SRAM' (D-03 parity gate).
+    - VPP shown only when vpp_mv > 0 AND electrical-type != 'SRAM' (parity gate).
     """
     if not eproms_data:
         logger.info("No EPROMs to display.")

--- a/firestarter/eprom_operations.py
+++ b/firestarter/eprom_operations.py
@@ -118,7 +118,7 @@ _FLASH4_PROTOCOL_ID = 5
 # ~9375 us on an Uno.
 WRITE_BLOCK_TIMEOUT_FALLBACK_S = 120.0
 
-# HOST-03 / D-20: the three per-byte program-budget ids _budget_failure_hint_
+# the three per-byte program-budget ids _budget_failure_hint_
 # message keys on -- MSG_ERR_MAX_PULSES (0xBD), MSG_ERR_ENERGY_CAP (0xBE),
 # MSG_ERR_PULSE_TOO_WIDE (0xAE). Defined as raw ints (not imported names)
 # because this tuple lives in this module-level constant block, while
@@ -753,7 +753,7 @@ class EpromOperator:
             file_size = os.path.getsize(input_file_path)
             progress.start(file_size)
 
-            # HOST-02 / D-04: _setup_operation sets command_dict["address"]
+            # _setup_operation sets command_dict["address"]
             # ONLY when an --address was supplied, so .get("address", 0) is
             # exactly right for a full-chip write's start address (0) too --
             # write_eprom already forwards eprom_data_dict=cmd_data.
@@ -773,7 +773,7 @@ class EpromOperator:
                     hint = _boot_block_hint_message(response, protocol, mem_size)
                     budget_hint = _budget_failure_hint_message(response)
                     msg = response.message
-                    # HOST-03 / D-19: the boot-block hint (0xB3, flash4-only)
+                    # the boot-block hint (0xB3, flash4-only)
                     # and the budget-failure hint (0xBD/0xBE/0xAE) are
                     # disjoint by id today, but this composition does not
                     # rely on that -- appending whichever are present still
@@ -784,7 +784,7 @@ class EpromOperator:
                             msg = msg + " -- " + extra_hint
                     _raise_for_error_response(response, msg)
                 if response.type == "DATA":
-                    # HOST-02 / D-05: a mid-block MSG_DATA_PROGRESS frame is
+                    # a mid-block MSG_DATA_PROGRESS frame is
                     # NEVER acked -- the firmware is mid-block waiting for
                     # nothing, and on a Leonardo a stray buffered "OK" makes
                     # op_get_message return OP_MSG_ACK, so
@@ -1495,7 +1495,7 @@ class EpromOperator:
         try:
             with open(log_path, "w") as fh:
                 fh.write(
-                    f"# XACT-02 fault-injection log ({direction}, {fault_form})\n"
+                    f"# fault-injection log ({direction}, {fault_form})\n"
                     f"corrupted_transfer_surfaced_clean_error: {corrupted_ok}\n"
                     f"error_latency: {latency_str}\n"
                     f"sub_second_clean_error_no_2s_cascade: {cascade}\n"
@@ -1660,7 +1660,7 @@ class EpromOperator:
         try:
             with open(log_path, "w") as fh:
                 fh.write(
-                    "# XACT-02 per-frame NAK latency (established single-port connection)\n"
+                    "# per-frame NAK latency (established single-port connection)\n"
                     f"# port: {port}  fault_form: {fault_form}\n"
                     f"baseline_clean_command_ok: {baseline_ok}\n"
                     f"corrupted_frame_surfaced_error_no_silent_accept: {corrupted_surfaced_error}\n"
@@ -1819,7 +1819,7 @@ class EpromOperator:
         address_str: Optional[str] = None,
         pulse_us: int = 0,  # per-run pulse-width override (us; 0=not supplied, use the database value)
     ) -> bool:
-        # HOST-04 / D-14: per-run pulse override, riding the existing
+        # per-run pulse override, riding the existing
         # "pulse-delay" DB-dict key rather than adding a new wire field or
         # command. Four recorded points:
         # (a) this is consistency_check_eprom's read_settling_us/
@@ -2018,9 +2018,9 @@ class EpromOperator:
 
         A ``True`` return means only that the command sequence was **emitted**
         over the wire — it is never a claim that silicon actually left the
-        protected state. Protection state is not readable on this chip family
-        (Phase 119 D-12, Phase 117 D-05), so no return value from this method
-        can honestly say more than "the sequence was sent and the firmware
+        protected state. Protection state is not readable on this chip family,
+        so no return value from this method can honestly say more than
+        "the sequence was sent and the firmware
         reported OK".
 
         The capability refusal deciding *which* parts may reach this method at
@@ -2066,9 +2066,9 @@ class EpromOperator:
 
         A ``True`` return means only that the command sequence was **emitted**
         over the wire — it is never a claim that silicon actually entered the
-        protected state. Protection state is not readable on this chip family
-        (Phase 119 D-12, Phase 117 D-05), so no return value from this method
-        can honestly say more than "the sequence was sent and the firmware
+        protected state. Protection state is not readable on this chip family,
+        so no return value from this method can honestly say more than
+        "the sequence was sent and the firmware
         reported OK".
 
         The capability refusal deciding *which* parts may reach this method at

--- a/firestarter/eprom_operations.py
+++ b/firestarter/eprom_operations.py
@@ -87,7 +87,7 @@ def _raise_for_error_response(response, message: str) -> None:
     `message` is the already-composed exception message string (callers may
     prepend a phase-name prefix for EpromOperationError framing; the raw
     firmware text is passed through unchanged for ProtocolNotImplementedError
-    so firmware owns rendering per D-02).
+    so firmware owns rendering).
     """
     from firestarter.messages import MSG_ERR_PROTOCOL_NOT_IMPLEMENTED
 
@@ -287,11 +287,11 @@ def build_flags(
         flags |= FLAG_VERBOSE
     # The FLAG_SKIP_SDP_UNLOCK bit is mapped HERE, inside build_flags, rather
     # than OR-ed in afterwards by a caller the way FLAG_OUTPUT_ENABLE /
-    # FLAG_CHIP_ENABLE are in cli_handlers._build_op_flags — D-19: every wire
+    # FLAG_CHIP_ENABLE are in cli_handlers._build_op_flags -- every wire
     # flag bit stays mapped in the one function that maps wire flags.
     # Emitted unconditionally when requested: firmware never reads this bit on
     # a protocol other than 0x0D, so no per-protocol branch belongs in a
-    # flag-mapping function. D-18's "warn and proceed" for a non-0x0D chip is
+    # flag-mapping function. The "warn and proceed" path for a non-0x0D chip is
     # the handler's job, not this function's.
     if skip_sdp_unlock:
         flags |= FLAG_SKIP_SDP_UNLOCK
@@ -516,7 +516,7 @@ class EpromOperator:
     ):
         """A context manager to handle EPROM operation setup and teardown.
 
-        ``fault_inject_outgoing`` (Phase 53-04 / XACT-02, dev-only) is forwarded to
+        ``fault_inject_outgoing`` (dev-only) is forwarded to
         ``find_and_connect`` so the setup command frame can be corrupted at connection
         time. Default None keeps the production path byte-identical.
         """
@@ -758,7 +758,7 @@ class EpromOperator:
             # exactly right for a full-chip write's start address (0) too --
             # write_eprom already forwards eprom_data_dict=cmd_data.
             start_addr = (eprom_data_dict or {}).get("address", 0)
-            # HOST-02 / Pitfall 1: latches True on the first successfully
+            # Latches True on the first successfully
             # -applied mid-block progress frame (_apply_write_progress
             # returning True), so the chunk-handoff update() below stops
             # firing -- see its own comment for why it must not simply be
@@ -812,10 +812,10 @@ class EpromOperator:
                     # COBS-decodes in place, verifies CRC8-CCITT over the payload.
                     # Frame layout (ADR §4.3): b"#" + COBS(payload + CRC8) + b"\x00".
                     # Assembled as ONE bytes object and sent in a single send_bytes call
-                    # (atomic-write mandate, ADR §4.1 / T-50-05 SAFE-01 timing guard).
+                    # (atomic-write mandate; timing guard).
                     self.comm.send_bytes(frame)
                     if not firmware_drives_bar:
-                        # HOST-02 / Pitfall 1: the two progress sources measure
+                        # The two progress sources measure
                         # different things -- bytes SENT (this handoff) versus
                         # bytes PROGRAMMED (the firmware's own 0xE0 frames) --
                         # and this one runs first. Without this latch, the bar
@@ -839,7 +839,7 @@ class EpromOperator:
     ):
         """Main phase handler for reading data.
 
-        Phase 8 W-04: the firmware now wraps each chip-byte chunk inside a
+        The firmware wraps each chip-byte chunk inside a
         MSG_DATA_CHUNK ID frame instead of emitting raw bytes after a DATA:
         text prefix.  The response loop distinguishes:
           - DATA response with payload set → MSG_DATA_CHUNK; extract raw bytes.
@@ -1015,7 +1015,7 @@ class EpromOperator:
                 logger.info(f"Run {i}/{runs}: reading {eprom_name} -> {run_path}")
                 start_t = time.time()
 
-                # Reuse the EXACT code path read_eprom uses (D-03 reuse-not-duplicate)
+                # Reuse the EXACT code path read_eprom uses -- do not duplicate
                 try:
                     with self._operation_context(
                         eprom_name,
@@ -1125,7 +1125,7 @@ class EpromOperator:
                     offs_str = ", ".join(f"0x{o:0{width}X}" for o in head)
                     print(f"First {max_diffs} divergent offsets: {offs_str}")
 
-            # Cleanup (D-10 #5)
+            # Cleanup
             if not keep_files:
                 shutil.rmtree(output_dir, ignore_errors=True)
 
@@ -1286,7 +1286,7 @@ class EpromOperator:
         output_path = Path(output_dir)
         output_path.mkdir(parents=True, exist_ok=True)
 
-        # Build fault hooks for the outgoing path (D-02 fault forms)
+        # Build fault hooks for the outgoing path
         def _corrupt_crc8(frame: bytes) -> bytes:
             """Flip the CRC8 byte (frame[-2]) — frame[-1] is the 0x00 delimiter."""
             return frame[:-2] + bytes([frame[-2] ^ 0x01]) + b"\x00"
@@ -1313,7 +1313,7 @@ class EpromOperator:
         # Incoming: connect cleanly, swap to FaultInjectingSerialCommunicator, run the
         #   read; the host decoder catches the mutated fw->host frame.
         # error_latency_s captures wall-clock from corrupted-attempt start to the
-        #   surfaced error so XACT-02's "sub-second clean error, no 2 s cascade" can be
+        #   surfaced error so the "sub-second clean error, no 2 s cascade" bar can be
         #   measured (the harness reports it; the firmware's actual latency decides it).
         corrupted_ok = False
         error_latency_s: Optional[float] = None
@@ -1398,7 +1398,7 @@ class EpromOperator:
             corrupted_detail = f"{direction}: {type(e).__name__} (expected): {e}"
 
         # Persist the latency + verdict so the operator can confirm the sub-second
-        # clean error (no 2 s cascade) XACT-02 requires.
+        # clean error (no 2 s cascade) the fast-fail bar requires.
         self._write_fault_inject_log(
             output_path,
             direction,
@@ -1477,7 +1477,7 @@ class EpromOperator:
         error_latency_s: Optional[float],
         detail: str,
     ) -> None:
-        """Write the XACT-02 fault-injection log (one per cycle).
+        """Write the fault-injection log (one per cycle).
 
         Records the measured error latency so the operator can confirm the
         sub-second clean error (no 2 s timeout cascade) the acceptance requires.
@@ -1520,7 +1520,7 @@ class EpromOperator:
         output_dir: Optional[str] = None,
         port: Optional[str] = None,
     ) -> bool:
-        """XACT-02 outgoing PER-FRAME latency measurement on an ESTABLISHED single-port
+        """Outgoing PER-FRAME latency measurement on an ESTABLISHED single-port
         connection (53-04 harness refinement).
 
         Unlike fault_inject_cycle (which corrupts the connection-SETUP frame and so
@@ -1647,7 +1647,7 @@ class EpromOperator:
         latency_str = (
             f"{nak_latency_s:.3f}s" if nak_latency_s is not None else "unmeasured"
         )
-        # Sub-second is the XACT-02 fast-fail bar for a complete corrupt frame; a
+        # Sub-second is the fast-fail bar for a complete corrupt frame; a
         # drop-delimiter frame is bounded by the firmware inter-byte deadline (~1 s).
         if nak_latency_s is None:
             verdict = "UNKNOWN"
@@ -1857,7 +1857,7 @@ class EpromOperator:
             logger.info(f"Writing {input_file_path} to {eprom_name.upper()}")
             start_time = time.time()
 
-            # HOST-01 / D-09-D-10: _write_block_timeout() MUST be read here,
+            # _write_block_timeout() MUST be read here,
             # inside this `with` block -- _operation_context's `finally`
             # disconnects and sets self.comm to None once it exits (same
             # constraint the seen_message_ids check below already relies
@@ -2008,7 +2008,7 @@ class EpromOperator:
 
         This operation is **payload-free**: firmware leaves ``init``/``end``
         NULL for CMD_SDP_UNLOCK, so no ``#`` data
-        frame is written and there is no host ``DONE`` round-trip. Phase 119's
+        frame is written and there is no host ``DONE`` round-trip. The firmware's
         correction still applies here: NULL ``init``/``end`` does NOT skip the
         INIT and END frame pairs themselves — both ``_execute_phase("INIT", ...)``
         and ``_execute_phase("END", ...)`` still run and both ack; only the
@@ -2056,7 +2056,7 @@ class EpromOperator:
 
         This operation is **payload-free**: firmware leaves ``init``/``end``
         NULL for CMD_SDP_LOCK, so no ``#`` data
-        frame is written and there is no host ``DONE`` round-trip. Phase 119's
+        frame is written and there is no host ``DONE`` round-trip. The firmware's
         correction still applies here: NULL ``init``/``end`` does NOT skip the
         INIT and END frame pairs themselves — both ``_execute_phase("INIT", ...)``
         and ``_execute_phase("END", ...)`` still run and both ack; only the
@@ -2096,7 +2096,7 @@ class EpromOperator:
 
     # Protocol IDs whose firmware handler (configure_sram) leaves a NULL
     # firestarter_operation_main for CMD_BLANK_CHECK, causing 0xA4
-    # MSG_ERR_EMPTY_INPUT.  These are all SRAM families (D-30 host-side fix).
+    # MSG_ERR_EMPTY_INPUT. These are all SRAM families (host-side fix).
     _SRAM_PROTO_IDS = frozenset({0x0E, 0x27, 0x28, 0x29})
 
     def check_eprom_blank(
@@ -2228,7 +2228,7 @@ class EpromOperator:
         its own operation, extended here to a query rather than a mutating
         command. It is never a claim that the payload's decode is a
         correct or even a *definite* state -- classification of the raw
-        byte and the decode byte into one of D-09's eight answer classes is
+        byte and the decode byte into one of the eight answer classes is
         `firestarter.lock_status.classify_protection_response`'s job
         entirely; this method makes no claim whatsoever about the chip's
         protection state.

--- a/firestarter/exceptions.py
+++ b/firestarter/exceptions.py
@@ -104,7 +104,7 @@ class FirmwareOperationError(Exception):
 class ChipNotFoundError(Exception):
     """Raised when a chip name cannot be resolved in the database.
 
-    Wired in Phase 39 (chip_resolver.py).
+    Wired in chip_resolver.py.
     """
 
     pass

--- a/firestarter/firmware.py
+++ b/firestarter/firmware.py
@@ -92,7 +92,7 @@ _BOARD_FLASH_METHODS = {
 _PORTLESS_FLASH_METHODS = frozenset({FLASH_METHOD_DFU})
 
 
-# HOST-01 / D-17 — accepted deviation, not a defect to fix.
+# accepted deviation, not a defect to fix.
 #
 # The milestone plan prescribed extracting a flasher-strategy class hierarchy
 # (one strategy per install mechanism) when the py32 DFU install path landed.
@@ -648,7 +648,7 @@ class FirmwareManager:
             # bootloader, or how to install pyusb) — surface it as the module's
             # own error type rather than leaking a USB-layer exception.
             #
-            # HOST-03 / D-11: a genuine MISMATCH never reaches this `if ok:`
+            # a genuine MISMATCH never reaches this `if ok:`
             # branch below — _verify_readback() raises DfuProtocolError (a
             # DfuError), which lands here and is converted to
             # FirmwareOperationError, which the CLI's map_typed_errors

--- a/firestarter/firmware.py
+++ b/firestarter/firmware.py
@@ -34,7 +34,7 @@ from firestarter.constants import (
     FLAG_FORCE,
 )
 from firestarter.exceptions import (
-    FirmwareOperationError,  # wired by the USB DFU install path (was D-01 orphan)
+    FirmwareOperationError,  # wired by the USB DFU install path
     FirmwareOutdatedError,
     ProgrammerNotFoundError,
     SerialError,
@@ -56,7 +56,7 @@ _LINK_NEXT_RE = re.compile(r'<([^>]+)>;\s*rel="next"')
 
 
 class ReleaseInfo(TypedDict):
-    """Structured release entry returned by list_releases (D-12 schema)."""
+    """Structured release entry returned by list_releases."""
 
     version: str  # tag_name from GitHub API
     tag: str  # raw tag_name (same as version for firmware releases)
@@ -100,7 +100,7 @@ _PORTLESS_FLASH_METHODS = frozenset({FLASH_METHOD_DFU})
 # `flash_method()` router. That is a deliberate, accepted deviation: it does
 # the same dispatch job with far less new surface, and `_install_with_avrdude`
 # below is left completely untouched — rewriting it into a strategy object is
-# explicitly out of scope for Phase 127 (and for whatever lands next).
+# explicitly out of scope here (and for whatever lands next).
 #
 # The pending todo `avrdude-mcu-detection-fallback` was reviewed during Phase
 # 127 and deliberately not folded into this router, precisely because it
@@ -212,7 +212,7 @@ class FirmwareManager:
             if payload and ":" in payload:
                 # Identity is "<version>:<board>[:<buf>[:<maxchunk>]]". Only the
                 # version and board are user-facing / release-relevant; <buf> and
-                # <maxchunk> are wire-negotiation fields (Phase 53/54) that must
+                # <maxchunk> are wire-negotiation fields that must
                 # not leak into the printout or the firmware-release asset lookup
                 # (firestarter_<board>.hex). Take only the first two fields.
                 parts = payload.split(":")
@@ -324,7 +324,7 @@ class FirmwareManager:
     ) -> Tuple[Optional[str], Optional[str]]:  # noqa: UP006
         """Router: returns (resolved_version, download_url) or (None, None) on failure.
 
-        channel='stable'  → delegates to fetch_latest_release_info (D-15 back-compat shim).
+        channel='stable'  → delegates to fetch_latest_release_info (back-compat shim).
         channel='pre'     → paginates /releases, filters prerelease=True, sorts by PEP 440
                             descending, takes highest; falls back to stable if none.
         channel='pinned'  → fetches /releases/tags/{version} directly.
@@ -415,7 +415,7 @@ class FirmwareManager:
         channel_filter='pre'    → prerelease only.
         channel_filter='stable' → stable only.
 
-        Returns a flat list of ReleaseInfo dicts (D-12 schema: version, tag, channel,
+        Returns a flat list of ReleaseInfo dicts (version, tag, channel,
         published, asset_url).
         """
         try:

--- a/firestarter/frame_parser.py
+++ b/firestarter/frame_parser.py
@@ -30,7 +30,7 @@ MAGIC_PREAMBLE: bytes = b"\xaa\x55\xaa\x55"
 def _build_crc8_table() -> bytes:
     """Precompute the 256-byte CRC8-CCITT lookup table.
 
-    Algorithm pinned by CONTEXT §D-03: polynomial 0x07, seed 0x00,
+    Algorithm: polynomial 0x07, seed 0x00,
     no reflection, no final XOR. Same algorithm the firmware Unity suite
     asserts (firestarter test_messages/test_rurp_log_id.cpp).
     """

--- a/firestarter/hardware.py
+++ b/firestarter/hardware.py
@@ -159,8 +159,8 @@ class HardwareManager:
         -> disconnect handshake but returns data rather than printing (same
         relationship sample_vpp_mv/_sample_one_voltage bears to
         read_vpp_voltage). This is the auto-capture source for both
-        AutoCapture.hw_revision and AutoCapture.fw_board_identity (D-01,
-        D-02) -- a coarse bucket or an honest None is an accepted outcome
+        AutoCapture.hw_revision and AutoCapture.fw_board_identity -- a coarse
+        bucket or an honest None is an accepted outcome
         for either field, never a fabricated value. Opens ONE serial read
         (energize/query only) -- no VPP-set, no wire-dict, no --force
         (SAFE-02 clean). Does NOT change get_hardware_revision's existing

--- a/firestarter/hardware.py
+++ b/firestarter/hardware.py
@@ -163,7 +163,7 @@ class HardwareManager:
         bucket or an honest None is an accepted outcome
         for either field, never a fabricated value. Opens ONE serial read
         (energize/query only) -- no VPP-set, no wire-dict, no --force
-        (SAFE-02 clean). Does NOT change get_hardware_revision's existing
+        Does NOT change get_hardware_revision's existing
         bool contract -- the `dev hw` CLI command depends on that.
 
         `comm.firmware_identity` is read before `comm.expect_ack()`:

--- a/firestarter/ic_layout.py
+++ b/firestarter/ic_layout.py
@@ -212,7 +212,7 @@ class EpromSpecBuilder:
         """
         if protocol_id is not None:
             # 0x35 (ITE EC MCU, 0 DB chips) and 0x39 (phantom, 0 DB chips) removed
-            # in Phase 57; no DB chip uses either protocol. Firmware still
+            # earlier; no DB chip uses either protocol. Firmware still
             # dispatches both → configure_flash4 for forward-compat (memory.cpp:89);
             # host routes them to not_implemented (excluded from KNOWN_PROTOCOLS).
             if protocol_id in self._PROTOCOL_DISPLAY_NAME:
@@ -498,12 +498,12 @@ class EpromSpecBuilder:
         electrical_type: Optional[str],  # noqa: UP006
         protocol_id: Optional[int] = None,  # noqa: UP006
     ) -> str:
-        """Return the user-facing chip-type display label (D-04 single source of truth).
+        """Return the user-facing chip-type display label (single source of truth).
 
         Looks up ``electrical_type`` in ``_ELECTRICAL_TYPE_LABEL`` (the curated
         ground-truth map from the DB ``electrical.type`` field).  When
         ``electrical_type`` is absent or empty — e.g. legacy user-override DB
-        entries that predate the ``electrical.type`` field (D-05 fallback) — falls
+        entries that predate the ``electrical.type`` field (fallback) — falls
         back to the protocol-based label via ``get_chip_type_string``.
 
         Both ``build_specifications`` (info view) and ``print_eprom_list_table``

--- a/firestarter/lock_status.py
+++ b/firestarter/lock_status.py
@@ -128,8 +128,7 @@ def classify_protection_response(
     if forced and gate_token != GATE_TOKEN_READ_PERMITTED:
         return _CLASS_UNADJUDICATED_PROBE, (
             f"--force ran the read past the table's {gate_token!r} refusal; "
-            "the result is an unadjudicated probe, never a state claim "
-            "(D-07)."
+            "the result is an unadjudicated probe, never a state claim."
         )
 
     if gate_token != GATE_TOKEN_READ_PERMITTED:

--- a/firestarter/lock_status.py
+++ b/firestarter/lock_status.py
@@ -61,7 +61,7 @@ DECODE_INDETERMINATE = 0xFF
 
 # The operational-failure class also covers a truncated or missing payload
 # (see `classify_protection_response` step 3 below) -- this constant names
-# it once so both use sites (the D-04 unknown-command mapping and the
+# it once so both use sites (the unknown-command mapping and the
 # truncated-payload guard) stay in sync with the same token.
 _CLASS_FIRMWARE_OUTDATED = "firmware_outdated"
 _CLASS_UNADJUDICATED_PROBE = "unadjudicated_probe"
@@ -96,7 +96,7 @@ EXIT_BY_CLASS: Mapping[str, int] = {
 def exit_code_for_class(class_token: str) -> int:
     """Look up `class_token`'s exit code. Raises `KeyError` on an unknown
     token -- never `.get(token, 1)`. A silent default here would let a new,
-    unclassed D-09 token silently exit non-zero-but-wrong instead of failing
+    unclassed token silently exit non-zero-but-wrong instead of failing
     loudly the moment it is introduced.
     """
     return EXIT_BY_CLASS[class_token]
@@ -166,7 +166,7 @@ def classify_protection_response(
 
 
 def render_lock_status(class_token: str, reason: str, raw_byte: int | None) -> str:
-    """D-08's rendering surface: the class token first, then the prose.
+    """The rendering surface: the class token first, then the prose.
 
     The class token is always the string's first whitespace-delimited
     field, so a caller or a test can assert on the token alone without
@@ -174,7 +174,7 @@ def render_lock_status(class_token: str, reason: str, raw_byte: int | None) -> s
     by CALLING `sdp_honesty.unreadable_state_caveat()` -- never re-authored
     or re-worded, so the sentence stays byte-identical everywhere it is
     used. `raw_byte`, when not `None`, is always rendered in hex, including
-    on the not-readable-because-unrecognised path: D-03's probe depends on
+    on the not-readable-because-unrecognised path: the probe depends on
     the raw observation surviving even when the decode did not resolve.
     """
     body = reason

--- a/firestarter/main.py
+++ b/firestarter/main.py
@@ -5,7 +5,7 @@ Copyright (c) 2024 Henrik Olsson
 
 Permission is hereby granted under MIT license.
 
-Entry-point stub for the `firestarter` console script (Phase 41 / D-08, D-16).
+Entry-point stub for the `firestarter` console script.
 Re-exports Click's ``cli`` as ``main`` so the ``firestarter.main:main`` entry
 point declared in pyproject.toml keeps resolving without churn after the
 argparse -> Click migration.

--- a/firestarter/protection_readability.py
+++ b/firestarter/protection_readability.py
@@ -79,17 +79,17 @@ REASON_NOT_READABLE = "documented as not having a readable protection state"
 REASON_UNDOCUMENTED_ALIAS = "not documented in lockable-proms.md"
 REASON_READ_PERMITTED = "every alias documented-readable; silicon read permitted"
 
-# A **gate** token, not one of D-09's eight output classes — the CLI never
+# A **gate** token, not one of the eight output classes — the CLI never
 # prints this string. `protection_gate_for_entry` returns it
 # internally to mean "proceed to the silicon read"; `lock_status.py` (plan
-# 151-08+) is the only place D-09's eight class tokens are assembled and
+# ) is the only place the eight class tokens are assembled and
 # emitted.
 GATE_TOKEN_READ_PERMITTED: str = "read_permitted"
-# Four of D-09's eight output classes are reachable from THIS module — never
+# Four of the eight output classes are reachable from THIS module — never
 # `protected` and never `unprotected`, both of which require a real silicon
 # read and therefore live only in `lock_status.py`, whose
-# signature accepts a device response and this module's does not (D-12 leg
-# 4). The literals below are the same class tokens D-09 names; this module
+# signature accepts a device response and this module's does not. The
+# literals below are the same class tokens; this module
 # only ever hands one of these five (including GATE_TOKEN_READ_PERMITTED
 # above) back to a caller.
 GATE_TOKEN_NO_MECHANISM: str = "no_mechanism"
@@ -105,28 +105,28 @@ GATE_TOKEN_UNDOCUMENTED_ALIAS: str = "undocumented_alias"
 # `chip_database.json` (`programming.algorithm`, summed per protocol id);
 # 405 + 40 + 84 + 217 == 746, the full row count.
 NO_MECHANISM_PROTOCOL_IDS: frozenset[int] = frozenset({7, 8, 11, 14, 39, 40, 41})
-# 405 rows — D-09's seven named no-mechanism algorithms: UV-EPROM 0x07
+# 405 rows — the seven named no-mechanism algorithms: UV-EPROM 0x07
 # (170) / 0x08 (127) / 0x0B (32); SRAM/NVRAM 0x0E (20) / 0x27 (2) / 0x28
 # (34) / 0x29 (20). 170+127+32+20+2+34+20 == 405.
 
 NOT_IMPLEMENTED_PROTOCOL_IDS: frozenset[int] = frozenset({16, 52})
-# 40 rows — OD-2 / 151-DESIGN.md §4's corrected census, superseding
+# 40 rows — the corrected census, superseding
 # VALIDATION.md's earlier figure of 39:
 #   0x10 (16, 39 rows: Intel/AMD/Catalyst/ST) — documented-readable per
 #   `lockable-proms.md`, but this release deliberately does not implement
 #   the read.
-#   0x34 (52, 1 row: XICOR/X88C64P,X88C64S) — D-09's seven no-mechanism
+#   0x34 (52, 1 row: XICOR/X88C64P,X88C64S) — the seven no-mechanism
 #   algorithms sum to 405, not 406; this row is the 406th and lands in no
-#   class under D-09's prose as written. It carries
+#   class under the prose as written. It carries
 #   `support_status: "protocol-not-implemented"` and
 #   `protect_off_before: true`, so classing it `no_mechanism` would assert
 #   an absence of mechanism upstream directly contradicts — the
-#   fabricated claim LOCK-03/LOCK-04 forbid. `not_implemented` is the
+#   fabricated claim. `not_implemented` is the
 #   honest reading for both members: neither has code in this project that
 #   reads its protection state, for two different reasons.
 
 NOT_READABLE_PROTOCOL_IDS: frozenset[int] = frozenset({13})
-# 84 rows — the 0x0D EEPROM_PARALLEL family LOCK-03 names. No curated
+# 84 rows — the 0x0D EEPROM_PARALLEL family. No curated
 # token table is consulted for this protocol id: every row is documented
 # as not having a readable protection state (`sdp_capability.py`'s SDP
 # lock/unlock capability is a different question — whether the *command*
@@ -550,9 +550,9 @@ DOCUMENTED_NOT_READABLE_TOKENS: frozenset[str] = frozenset(
 # tiebreak rule in words: where the source document's table row and its own
 # restatements disagree about whether a token is covered, the token takes the
 # **more restrictive** readability state -- it is not adjudicated per entry by
-# curator judgement (D-06's rejected alternative; DATA-04 forbids exactly that).
+# curator judgement -- a rejected alternative, and forbidden.
 # Consequence, stated so it cannot be missed: the worked
-# `W29C020,W29C020C,W29C022` DB entry refuses under D-06 regardless of how this
+# `W29C020,W29C020C,W29C022` DB entry refuses regardless of how this
 # tiebreak resolves, because `W29C022` is undocumented either way -- the
 # tiebreak changes only how many offending aliases the refusal names (one vs.
 # two), never the entry's verdict. C-18, recorded alongside: all three aliases

--- a/firestarter/protection_readability.py
+++ b/firestarter/protection_readability.py
@@ -184,7 +184,7 @@ def protection_gate_for_entry(
             f"protection_gate_for_entry: no entry for {display_name.upper()!r}. "
             "The caller must resolve the chip before asking about its "
             "protection state -- a falsy/None entry means the caller did "
-            "not. None of D-09's eight output classes means 'chip "
+            "not. None of the eight output classes means 'chip "
             "unknown', so this function never invents one; the CLI must "
             "resolve the chip via db.get_eprom() and raise "
             "ChipNotFoundError before ever reaching this predicate."
@@ -214,7 +214,7 @@ def protection_gate_for_entry(
         if protocol_id == 0x10:
             detail = (
                 "documented readable per lockable-proms.md, but this "
-                "release implements no read for protocol 0x10 (D-02)"
+                "release implements no read for protocol 0x10"
             )
         else:
             detail = (
@@ -265,7 +265,7 @@ def protection_gate_for_entry(
         "NOT_IMPLEMENTED_PROTOCOL_IDS, NOT_READABLE_PROTOCOL_IDS or "
         "CURATION_PROTOCOL_IDS -- a synthetic or newly-added algorithm "
         "must be classed there before this row can be answered. No "
-        "default branch exists; a silent fallback would make D-12 leg 6's "
+        "default branch exists; a silent fallback would make the "
         "exhaustiveness walk unwritable."
     )
 

--- a/firestarter/py32_dfu.py
+++ b/firestarter/py32_dfu.py
@@ -94,7 +94,7 @@ STATUS_OK = 0x00
 _DFU_FUNCTIONAL_DESCRIPTOR = 0x21
 
 # DFU 1.1 §4.1.3 Table 4.2 offset 2 (bmAttributes) -- bit 1: upload capable
-# (bitCanUpload). HOST-03: `_verify_readback` reads this bit to decide
+# (bitCanUpload). `_verify_readback` reads this bit to decide
 # whether a DFU_UPLOAD readback can even be attempted; `DfuInterface.attributes`
 # was already parsed and stored by `_parse_functional_descriptor` before this
 # constant existed, so this is a consumer of that field, not a new parser.
@@ -548,7 +548,7 @@ class VerifyResult(enum.Enum):
 
     Honesty note: this is the first `enum` import anywhere in this codebase.
     The project's existing result-constant idiom (see `firmware.py`'s
-    `FLASH_METHOD_*`) is module-level strings plus a dict router; D-10 named
+    `FLASH_METHOD_*`) is module-level strings plus a dict router; the
     an enum specifically for this state, and that locked decision -- not a
     change of house style -- is why this class exists in that shape.
     """
@@ -701,7 +701,7 @@ class Py32DfuFlasher:
             )
             finish_base, next_block = self._download_plain(interface, payload)
 
-        # HOST-03 / D-09..D-12: verify what was actually written before ever
+        # Verify what was actually written before ever
         # leaving DFU mode. _verify_readback() raises DfuProtocolError on a
         # genuine MISMATCH (byte difference or truncated read); the two
         # SKIPPED_* outcomes are soft and never raise. Named unqualified
@@ -824,7 +824,7 @@ class Py32DfuFlasher:
         self._dnload(0, bytes(payload))
         self._wait_ready(f"DfuSe command 0x{command:02X}")
 
-    # -- HOST-03: post-write readback verification --------------------------
+    # -- post-write readback verification -----------------------------------
 
     def _read_back(self, interface: DfuInterface, base: int, length: int) -> bytes:
         """Read ``length`` bytes back from ``base`` over ``DFU_UPLOAD``.
@@ -870,7 +870,7 @@ class Py32DfuFlasher:
         Sets `self.verify_result` (and, for anything but a clean `VERIFIED`,
         `self.verify_reason`) in every branch, so a caller can inspect the
         outcome even on the branch that also raises. See `VerifyResult`'s
-        docstring for what each member means and D-09..D-12 for why the
+        docstring for what each member means, and below for why the
         branches are ordered this way.
         """
         if not interface.is_dfuse:

--- a/firestarter/py32_dfu.py
+++ b/firestarter/py32_dfu.py
@@ -574,7 +574,7 @@ class Py32DfuFlasher:
         self.erase_page_size = erase_page_size
         self.leave = leave
         self._interface: Optional[DfuInterface] = None  # noqa: UP045
-        # HOST-03 / D-10: set by `_verify_readback` once `flash()` has run;
+        # set by `_verify_readback` once `flash()` has run;
         # `None` means verification has not happened yet. See `VerifyResult`.
         self.verify_result: Optional[VerifyResult] = None  # noqa: UP045
         self.verify_reason: Optional[str] = None  # noqa: UP045

--- a/firestarter/sdp_capability.py
+++ b/firestarter/sdp_capability.py
@@ -116,11 +116,11 @@ SDP_CAPABLE_TOKENS: frozenset[str] = frozenset(
 # Ferroelectric RAM parts. Both carry `electrical.type == "EEPROM"` in the DB
 # (nothing in the DB says FRAM), so the existing `etype in ("SRAM", "FRAM")`
 # idiom (`eprom_operations.py`'s `_SRAM_PROTO_IDS` short-circuit) is blind to
-# them and no structural rule can find them — this is why HOST-04 says
+# them and no structural rule can find them — this is why the contract says
 # "resolved in code".
 FRAM_TOKENS: frozenset[str] = frozenset({"FM28V020", "MB85R256H"})
 
-# HOST-04's named pre-SDP class plus its identical-generation second sources.
+# The named pre-SDP class plus its identical-generation second sources.
 # `2817` sits on `DIP28_28C64` while `2804`/`2816` sit on `DIP24_2816`, so the
 # trio spans two pinouts and no pinout rule can express it (RESEARCH F-03).
 PRE_SDP_NAMED_TOKENS: frozenset[str] = frozenset(
@@ -231,11 +231,11 @@ def sdp_capability_for_entry(
 def sdp_capability(chip_name: str, db: Any) -> tuple[bool, str]:
     """Name-keyed SDP capability predicate: `sdp_capability_for_entry(db.get_eprom(chip_name), chip_name)`.
 
-    D-03 mechanism correction: CONTEXT.md D-03 said "no DB-loader coupling",
+    Mechanism correction: an earlier design said "no DB-loader coupling",
     which is **not achievable** — the predicate needs the part number, and
     `resolve_chip`'s programmer dict carries neither `protocol-id` nor `name`
     nor any part number (RESEARCH F-06, measured). The predicate is therefore
-    **name-keyed** with an injected `db`; D-03's semantics (pure function, no
+    **name-keyed** with an injected `db`; the semantics (pure function, no
     serial, no Click, `-> (allowed, reason)`) are preserved.
 
     The entry this function evaluates is the entry `db.get_eprom` **actually

--- a/firestarter/sdp_honesty.py
+++ b/firestarter/sdp_honesty.py
@@ -27,7 +27,7 @@ def unreadable_state_caveat() -> str:
     """Return the caveat clause alone, byte-identical to the wording
     formerly composed inline in `cli_handlers.py`'s retired `dev sdp`
     subcommand. Exposed separately from `emission_summary` because
-    Phase 134's report rows need the clause without the emission preamble.
+    Report rows need the clause without the emission preamble.
     """
     return (
         "The resulting protection state cannot be read back on this chip "
@@ -44,11 +44,11 @@ def emission_summary(mode: str, chip_name: str) -> str:
     merely a discipline: `get_response()` filters the entire INFO band out
     at `serial_comm.py:424`, so the operation layer literally cannot see the
     firmware's `0x5F`/`0x61` duration frame to plumb one through. No
-    lock/unlock state boolean appears either -- HOST-05's honesty floor.
+    lock/unlock state boolean appears either -- the honesty floor.
 
     Composed by calling `unreadable_state_caveat()` rather than duplicating
     its wording, so the two can never drift. `chip_name` is uppercased here
-    so a Phase 134/135 caller cannot forget to. Never appends a newline --
+    so a caller cannot forget to. Never appends a newline --
     the caller echoes.
     """
     chip_upper = chip_name.upper()
@@ -62,7 +62,7 @@ def map_unknown_cmd_to_outdated(
 ) -> FirmwareOutdatedError | None:
     """Map an unknown-command error to a `FirmwareOutdatedError`, or `None`.
 
-    D-14: an `EpromOperationError` whose `error_code` is
+    An `EpromOperationError` whose `error_code` is
     `MSG_ERR_UNKNOWN_CMD` means the attached firmware predates
     CMD_SDP_LOCK/CMD_SDP_UNLOCK and does not recognise this
     command at all. This exploits the one real asymmetry in the wire surface:

--- a/firestarter/sdp_honesty.py
+++ b/firestarter/sdp_honesty.py
@@ -65,8 +65,8 @@ def map_unknown_cmd_to_outdated(
     D-14: an `EpromOperationError` whose `error_code` is
     `MSG_ERR_UNKNOWN_CMD` means the attached firmware predates
     CMD_SDP_LOCK/CMD_SDP_UNLOCK and does not recognise this
-    command at all. This exploits the one real asymmetry in the wire surface
-    (HOST-06): an unknown COMMAND produces an error and is therefore
+    command at all. This exploits the one real asymmetry in the wire surface:
+    an unknown COMMAND produces an error and is therefore
     detectable after the fact, whereas an unknown flag BIT produces silence.
     Keyed on the message **id**, never the message text.
 
@@ -88,8 +88,8 @@ def map_unknown_cmd_to_outdated(
 def map_unknown_cmd_to_outdated_for_operation(
     exc: EpromOperationError, operation_label: str, chip_name: str
 ) -> FirmwareOutdatedError | None:
-    """Generalised sibling of `map_unknown_cmd_to_outdated` (Phase 151,
-    D-04): same contract, but the message names whatever `operation_label`
+    """Generalised sibling of `map_unknown_cmd_to_outdated`: same contract, but
+    the message names whatever `operation_label`
     it is given instead of the hard-coded literal `"SDP"`.
 
     Added rather than folding into `map_unknown_cmd_to_outdated` itself,

--- a/firestarter/serial_comm.py
+++ b/firestarter/serial_comm.py
@@ -45,7 +45,7 @@ from firestarter.exceptions import (
 
 # Re-exports for backward compatibility — test_decoder.py imports MAGIC_PREAMBLE,
 # LogMessage, Response, _crc8_ccitt directly from firestarter.serial_comm and must
-# keep passing UNCHANGED (SC#2 / D-07). The canonical definitions now live in
+# keep passing UNCHANGED. The canonical definitions now live in
 # frame_parser.py. _decode_param is also pulled in so _format_message /
 # _decode_id_frame in this module resolve it via the new leaf.
 from firestarter.frame_parser import (  # noqa: F401  — re-exports for test_decoder.py
@@ -142,7 +142,7 @@ class SerialCommunicator:
         # Set only within dev fault-inject scope; cleared after the single corrupted transfer.
         # getattr-guarded in send_json_command; this attribute is the formal default.
         self._fault_inject_outgoing: Optional[Callable[[bytes], bytes]] = None
-        # DEPRECATED (Phase 55 CAP-01): firmware_buffer_size was set by the Phase 53
+        # DEPRECATED: firmware_buffer_size was set by the earlier
         # identity-string parse (3rd colon-field). That parse block is removed; capacity
         # now comes from the MSG_OK_READY ack via firmware_max_chunk. Declaration kept
         # so conftest.py make_comm factory mirrors __init__ without breakage.
@@ -241,7 +241,7 @@ class SerialCommunicator:
         firmware's CRC8 verify (RESEARCH Pitfall 2).
 
         The full frame is assembled as a single ``bytes`` object and passed to
-        ``send_bytes()`` in ONE call (SAFE-01 sub-claim B — split-write forbidden).
+        ``send_bytes()`` in ONE call — a split write is forbidden.
         """
         self._log_command_details(command_dict)
         json_bytes = json.dumps(command_dict, separators=(",", ":")).encode("ascii")
@@ -398,7 +398,7 @@ class SerialCommunicator:
                             # in spirit: a hostile or corrupt ack
                             # must not be able to install an unbounded host
                             # timeout. Values outside this range leave
-                            # write_block_budget_s unset so the D-10 fallback
+                            # write_block_budget_s unset so the fallback
                             # applies.
                             if 1 <= value <= WRITE_BUDGET_MAX_S:
                                 self.write_block_budget_s = value
@@ -710,7 +710,7 @@ class SerialCommunicator:
         Option A, parses the major version (``ValueError``/``IndexError`` ->
         ``major=0``), refuses pre-v1.2 (``major < 3``) unless ``allow_pre_v12``,
         then enforces the 2.0.0 floor via ``_is_version_sufficient``. Never
-        reads ``os.environ`` (D-02 — env-var I/O is ``_probe_port``'s job).
+        reads ``os.environ`` — env-var I/O is ``_probe_port``'s job.
         """
         # RESEARCH §7 Option A: strip trailing alpha suffix before parsing so
         # direct callers (and future test harnesses) match production wire
@@ -971,7 +971,7 @@ class SerialCommunicator:
         strict gate; the single production caller that asks is
         ``FirmwareManager.check_current_firmware``.
 
-        ``fault_inject_outgoing`` (Phase 53-04 / XACT-02, dev-only) installs an
+        ``fault_inject_outgoing`` (dev-only) installs an
         outgoing-frame mutation hook on each probed communicator BEFORE the first
         ``send_json_command`` (the setup/handshake command). It defaults to None, so
         the production path is byte-identical. It exists because a READ's
@@ -1063,13 +1063,12 @@ class FaultInjectingSerialCommunicator(SerialCommunicator):
     NOT imported in production code. Used only within the dev fault-inject
     subcommand scope. Overrides _decode_id_frame to corrupt the body bytes
     before codec decode — exercising the host decoder's resync path (bounded-
-    desync + fail-fast per Phase 50 D-01).
+    desync + fail-fast).
 
     The body of _read_and_parse_lines() is UNCHANGED (ring-fence preserved,
-    GATE-1.8d). Only _decode_id_frame is overridden — this is the correct
+    the ring fence). Only _decode_id_frame is overridden — this is the correct
     injection point that does NOT touch the generator body (Pitfall 4 / T-53-04).
 
-    XACT-02 / Phase 53 Plan 02.
     """
 
     def __init__(

--- a/firestarter/serial_comm.py
+++ b/firestarter/serial_comm.py
@@ -405,7 +405,7 @@ class SerialCommunicator:
         return result
 
     # =================================================================
-    # DO NOT MODIFY — v1.9 RCA territory (GATE-1.8d)
+    # DO NOT MODIFY — v1.9 RCA territory
     # The body of this generator is the host-side baseline for v1.9's
     # read-bug RCA. Phase 26 baseline binaries (.planning/v1.6/
     # consistency-check-runs/W27C512-leonardo-20260526-*-v2*/) were
@@ -1088,7 +1088,7 @@ class FaultInjectingSerialCommunicator(SerialCommunicator):
         After the first call, _fault_fired is set and subsequent calls pass
         through unmodified (one-shot guard). This causes codec.decode_id_frame's
         CRC8 check to fail on the first call, which surfaces as None →
-        _read_and_parse_lines re-syncs without touching its body (GATE-1.8d).
+        _read_and_parse_lines re-syncs without touching its body.
         """
         if self._corrupt_incoming_once and not self._fault_fired:
             self._fault_fired = True

--- a/firestarter/submit.py
+++ b/firestarter/submit.py
@@ -503,7 +503,7 @@ def comment_via_gh(
 
 
 # ---------------------------------------------------------------------------
-# Browser tier + D-05 oversize escalation
+# Browser tier + oversize escalation
 # ---------------------------------------------------------------------------
 
 
@@ -522,7 +522,7 @@ def submit_via_browser(
     browser_open: Any = webbrowser.open,
     console: Any = None,
 ) -> str | None:
-    """Open a prefilled `issues/new` browser URL, degrading past the D-05
+    """Open a prefilled `issues/new` browser URL, degrading past the
     encoded-byte thresholds (RESEARCH §Oversize Handling / §Browser URL Facts).
 
     The byte measurement is ALWAYS on `len(url.encode("utf-8"))` of the
@@ -583,7 +583,7 @@ def submit_via_browser(
 
 
 # ---------------------------------------------------------------------------
-# submit_report: D-03 refuse gate + D-04 TTY/off-TTY dispatch
+# submit_report: refuse gate + TTY/off-TTY dispatch
 # ---------------------------------------------------------------------------
 
 
@@ -605,7 +605,7 @@ def submit_report(
     Plan-02 builder over the ALREADY-COMPLETED `report`/`saved_json_path`;
     it never re-runs the sweep and never re-derives the report.
 
-    Step 1 (D-03 refuse gate): when `is_submittable(report.auto_capture)`
+    Step 1 (refuse gate): when `is_submittable(report.auto_capture)`
     is `False`, prints the specific missing field name(s) among
     `chip`/`protocol`/`host_version` and returns WITHOUT calling
     `browser_open`, `run_fn`, `find_prior_report_fn`, or `confirm_fn`.
@@ -616,16 +616,16 @@ def submit_report(
     create, `gh` comment, browser) receives; a PII vector present in a
     step reason never reaches a seam unscrubbed.
 
-    Step 3 (D-09 dedup query -- runs BEFORE any ask, on EVERY reached
+    Step 3 (dedup query -- runs BEFORE any ask, on EVERY reached
     path, TTY or not): `find_prior_report_fn(fingerprint, run_fn=run_fn)`
     is called immediately after Step 2 and before the TTY branch, so
     "the check runs first" holds universally, not merely on
     an interactive run.
 
-    Step 4 (D-04/D-10 off-TTY): prints the issue URL and returns WITHOUT
+    Step 4 (off-TTY): prints the issue URL and returns WITHOUT
     ever calling `confirm_fn`, `submit_via_gh`, or `comment_via_gh_fn` --
     filing nothing (v1.21 SUB-01's ban on silent off-TTY submission
-    survives D-05's removal of the explicit flag). The Step 3 dedup
+    survives the removal of the explicit flag). The Step 3 dedup
     outcome is included in this output: the existing issue is named when
     one was found, or an explicit line states the check could not run
     when it was not. Quick task 260821-spg stopped echoing the sanitized

--- a/tests/__snapshots__/test_characterization.ambr
+++ b/tests/__snapshots__/test_characterization.ambr
@@ -145,8 +145,8 @@
     read               Reads the content from an EPROM and prints data to...
     reg                Direct access to registers: MSB, LSB and control...
     test               Run the community chip-validation sweep for CHIP.
-    validate-family    Run the per-family validation matrix Tier-3 runner...
-    write-cycle        Erase → write source image → read-back N times;...
+    validate-family    Run the per-family validation matrix Tier-3 runner.
+    write-cycle        Erase, write the source image, read back N times,...
   
   '''
 # ---
@@ -156,21 +156,14 @@
   
     Erase an EPROM, if supported.
   
-    TRAP #3 / D-13.3: this command keeps the inverse ``--blank-check`` polarity
-    (``is_flag=True default=False``) — opposite of ``write``'s ``--no-blank-
-    check``. Both polarities coexist verbatim from argparse.
+    ``-b``/``--blank-check`` requests a blank check performed **after** the
+    erase. Note the inverted sense against ``write``, whose ``-b``/``--no-blank-
+    check`` skips a check performed before it. On protocol ``0x0D`` the post-
+    erase check is not wired, so ``-b`` has no effect there.
   
-    D-153-04: unlike ``write``'s ``-b``, this command's ``-b``/``--blank-check``
-    requests a blank check performed **after** the erase, not skipped before it
-    — the inverse polarity above is a naming/default inversion, not just a
-    default flip. On protocol ``0x0D`` this post-erase check is not wired (no
-    ``operation_end`` arm was added to the software chip-erase handler), so
-    ``-b`` is a documented no-op there, not a discovered one.
-  
-    D-153-04 (RESEARCH A7): ``-s``/``--sector-address`` exists for the ``0x06``
-    sector-erase protocol. The ``0x0D`` software chip erase is device-global by
-    construction (the whole part is erased in one AN 0544B sequence) and ignores
-    any sector address given for it.
+    ``-s``/``--sector-address`` applies to the ``0x06`` sector-erase protocol.
+    The ``0x0D`` software chip erase is device-global by construction and
+    ignores any sector address given for it.
   
   Options:
     -f, --force                   Force, even if the VPP or chip id doesn't
@@ -188,14 +181,8 @@
   
     Firmware version.
   
-    Implements TRAP #4 (3-way --pre / --firmware-version / --stable mutex via a
-    single post-parse check at the top of the command body — WR-03; replaces the
-    earlier per-option callback _check_install_mutex which depended on Click's
-    left-to-right option-processing order) and TRAP #5 (firmware-version
-    validator via custom Click ParamType _FirmwareVersionType). D-14 narrow
-    upgrade: the post-parse `--json requires --list` check uses `raise
-    click.UsageError(...)` (exit-2 + "Usage:" formatting preserved from the
-    argparse `fw_parser.error()` form).
+    ``--pre``, ``--firmware-version`` and ``--stable`` are mutually exclusive;
+    passing more than one is refused before anything is installed.
   
   Options:
     -i, --install                   Try to install the latest firmware.
@@ -232,14 +219,8 @@
   
     Firmware version.
   
-    Implements TRAP #4 (3-way --pre / --firmware-version / --stable mutex via a
-    single post-parse check at the top of the command body — WR-03; replaces the
-    earlier per-option callback _check_install_mutex which depended on Click's
-    left-to-right option-processing order) and TRAP #5 (firmware-version
-    validator via custom Click ParamType _FirmwareVersionType). D-14 narrow
-    upgrade: the post-parse `--json requires --list` check uses `raise
-    click.UsageError(...)` (exit-2 + "Usage:" formatting preserved from the
-    argparse `fw_parser.error()` form).
+    ``--pre``, ``--firmware-version`` and ``--stable`` are mutually exclusive;
+    passing more than one is refused before anything is installed.
   
   Options:
     -i, --install                   Try to install the latest firmware.
@@ -358,62 +339,27 @@
   
     Writes a binary file to an EPROM.
   
-    TRAP #3 / D-13.3: ``--no-blank-check`` uses ``is_flag=True,
-    flag_value=False, default=True`` so the presence of ``-b`` flips
-    ``blank_check`` to False (mirrors argparse ``store_false default=True``).
-    The inverse ``--blank-check`` polarity lives on the ``erase`` command — both
-    polarities coexist verbatim per the rationale lock.
+    Blank check and erase are separate steps:
+      -b, --no-blank-check  skip the blank check only -- a pre-write erase
+                            still runs on electrically-erasable chips
+      --skip-erase          skip the pre-write erase as well
   
-    Phase 92 decouple: ``-b`` now skips ONLY the blank check. The pre-write
-    erase still runs for electrically-erasable chips (FLAG_CAN_ERASE) so ``write
-    -b`` on a non-blank flash/EEPROM works. Use ``--skip-erase`` to also skip
-    the erase (previously implied by ``-b``) for already-blank or non-erasable
-    parts.
+    On protocols 0x0D and 0x05 the write path performs no pre-write blank check
+    at all, so -b is a no-op on those families and is not needed to write a non-
+    blank part. It remains effective on every other protocol.
   
-    Phase 153 (ERASE-01/ERASE-02): since this phase, ``-b``/``--no-blank-check``
-    is **unread** on protocols ``0x0D`` and ``0x05`` — neither protocol's write
-    path performs a pre-write blank check any more, so the flag is a no-op on
-    both families and is not needed to write a non-blank part on either one. The
-    flag remains live, with its Phase 92 meaning above, on every other protocol.
-    This does not change the paragraph above: the erase/blank-check decoupling
-    it describes still governs whichever protocols still read the flag.
+    --skip-sdp-unlock applies to protocol-0x0D chips, where the firmware unlocks
+    software data protection during write init. On any other protocol it has no
+    effect and the write proceeds. The host may also set it on its own when the
+    resolved chip is protocol-0x0D and its protection state cannot be read, and
+    always reports when it does.
   
-    TRAP #6 / D-17/D-18 (v1.22 HOST-02): ``--skip-sdp-unlock`` is exposed on
-    ``write`` ONLY — firmware auto-unlocks in ``eeprom28c_write_init`` and
-    nowhere else, so ``read``/``verify``/``blank``/``erase`` have nothing to
-    skip and the flag is deliberately absent from all four (D-17). On a non-
-    protocol-0x0D chip the flag has no effect: firmware never reads this bit
-    outside protocol 0x0D, so the host warns and proceeds rather than refusing
-    or silently dropping the bit — the bit is still emitted so a blanket-flag
-    script across a mixed batch produces identical wire frames (D-18). The host
-    may also set this bit **on its own**, without the user passing it, when the
-    resolved chip is protocol-0x0D and capability-refused
-    (``firestarter.sdp_capability``) — see the D-04 auto-set block below, which
-    always prints a mandatory, default-visible report line when it fires.
-  
-    TRAP #7 / D-14..D-18 (v1.31 HOST-04/HOST-05): ``--pulse-us`` overrides the
-    database program-pulse width for this run only. D-14: it rides the existing
-    ``"pulse-delay"`` wire key (``write_eprom``'s own ``pulse_us`` parameter,
-    plan 143-04's transport half) — no new command, no new wire field. D-15:
-    bounds are enforced by the option's own ``click.IntRange(1, 65535)``, which
-    refuses out of range at Click PARSE TIME, exit 2. The guarantee this gives
-    HOST-05 ("before any serial byte is sent") is NOT "before ``AppContext``
-    builds" — ``cli()``'s group callback runs first, before this command's own
-    parameters are even type-converted — the guarantee is that NOTHING in
-    ``cli()`` or ``AppContext`` construction opens a serial port, so a parse-
-    time refusal is still structurally before any serial byte. D-16: a value in
-    ``50001..65535`` is host-legal but firmware-refused on protocol ``0x0B``
-    only (``configure_eprom``'s ``energy_cap_us``-keyed pre-flight check,
-    ``MSG_ERR_PULSE_TOO_WIDE``) before any high voltage is enabled — the host
-    deliberately mirrors no table value to pre-empt it (that would require
-    duplicating ``energy_cap_us`` host-side). D-17: using the flag ALWAYS prints
-    a default-visible report line (see below) naming both the database pulse
-    replaced and the override — provenance, because a bench artifact or log
-    captured without the command line beside it cannot otherwise tell you the
-    pulse was not the database's. D-18: the flag exists on ``write`` ONLY,
-    mirroring the reasoning above for ``--skip-sdp-unlock`` —
-    ``read``/``verify``/``blank``/``erase`` emit no program pulse, so there is
-    nothing to override.
+    --pulse-us overrides the database program-pulse width for this run only, in
+    the range 1..65535 microseconds. Out-of-range values are refused before the
+    port is opened. A value above 50000 is refused by the firmware on protocol
+    0x0B before any high voltage is enabled. Using the flag always reports both
+    the database pulse and the override, so a log captured without its command
+    line still records which pulse was used.
   
   Options:
     -b, --no-blank-check      Skip the blank check before write (erase still
@@ -1308,62 +1254,27 @@
   
     Writes a binary file to an EPROM.
   
-    TRAP #3 / D-13.3: ``--no-blank-check`` uses ``is_flag=True,
-    flag_value=False, default=True`` so the presence of ``-b`` flips
-    ``blank_check`` to False (mirrors argparse ``store_false default=True``).
-    The inverse ``--blank-check`` polarity lives on the ``erase`` command — both
-    polarities coexist verbatim per the rationale lock.
+    Blank check and erase are separate steps:
+      -b, --no-blank-check  skip the blank check only -- a pre-write erase
+                            still runs on electrically-erasable chips
+      --skip-erase          skip the pre-write erase as well
   
-    Phase 92 decouple: ``-b`` now skips ONLY the blank check. The pre-write
-    erase still runs for electrically-erasable chips (FLAG_CAN_ERASE) so ``write
-    -b`` on a non-blank flash/EEPROM works. Use ``--skip-erase`` to also skip
-    the erase (previously implied by ``-b``) for already-blank or non-erasable
-    parts.
+    On protocols 0x0D and 0x05 the write path performs no pre-write blank check
+    at all, so -b is a no-op on those families and is not needed to write a non-
+    blank part. It remains effective on every other protocol.
   
-    Phase 153 (ERASE-01/ERASE-02): since this phase, ``-b``/``--no-blank-check``
-    is **unread** on protocols ``0x0D`` and ``0x05`` — neither protocol's write
-    path performs a pre-write blank check any more, so the flag is a no-op on
-    both families and is not needed to write a non-blank part on either one. The
-    flag remains live, with its Phase 92 meaning above, on every other protocol.
-    This does not change the paragraph above: the erase/blank-check decoupling
-    it describes still governs whichever protocols still read the flag.
+    --skip-sdp-unlock applies to protocol-0x0D chips, where the firmware unlocks
+    software data protection during write init. On any other protocol it has no
+    effect and the write proceeds. The host may also set it on its own when the
+    resolved chip is protocol-0x0D and its protection state cannot be read, and
+    always reports when it does.
   
-    TRAP #6 / D-17/D-18 (v1.22 HOST-02): ``--skip-sdp-unlock`` is exposed on
-    ``write`` ONLY — firmware auto-unlocks in ``eeprom28c_write_init`` and
-    nowhere else, so ``read``/``verify``/``blank``/``erase`` have nothing to
-    skip and the flag is deliberately absent from all four (D-17). On a non-
-    protocol-0x0D chip the flag has no effect: firmware never reads this bit
-    outside protocol 0x0D, so the host warns and proceeds rather than refusing
-    or silently dropping the bit — the bit is still emitted so a blanket-flag
-    script across a mixed batch produces identical wire frames (D-18). The host
-    may also set this bit **on its own**, without the user passing it, when the
-    resolved chip is protocol-0x0D and capability-refused
-    (``firestarter.sdp_capability``) — see the D-04 auto-set block below, which
-    always prints a mandatory, default-visible report line when it fires.
-  
-    TRAP #7 / D-14..D-18 (v1.31 HOST-04/HOST-05): ``--pulse-us`` overrides the
-    database program-pulse width for this run only. D-14: it rides the existing
-    ``"pulse-delay"`` wire key (``write_eprom``'s own ``pulse_us`` parameter,
-    plan 143-04's transport half) — no new command, no new wire field. D-15:
-    bounds are enforced by the option's own ``click.IntRange(1, 65535)``, which
-    refuses out of range at Click PARSE TIME, exit 2. The guarantee this gives
-    HOST-05 ("before any serial byte is sent") is NOT "before ``AppContext``
-    builds" — ``cli()``'s group callback runs first, before this command's own
-    parameters are even type-converted — the guarantee is that NOTHING in
-    ``cli()`` or ``AppContext`` construction opens a serial port, so a parse-
-    time refusal is still structurally before any serial byte. D-16: a value in
-    ``50001..65535`` is host-legal but firmware-refused on protocol ``0x0B``
-    only (``configure_eprom``'s ``energy_cap_us``-keyed pre-flight check,
-    ``MSG_ERR_PULSE_TOO_WIDE``) before any high voltage is enabled — the host
-    deliberately mirrors no table value to pre-empt it (that would require
-    duplicating ``energy_cap_us`` host-side). D-17: using the flag ALWAYS prints
-    a default-visible report line (see below) naming both the database pulse
-    replaced and the override — provenance, because a bench artifact or log
-    captured without the command line beside it cannot otherwise tell you the
-    pulse was not the database's. D-18: the flag exists on ``write`` ONLY,
-    mirroring the reasoning above for ``--skip-sdp-unlock`` —
-    ``read``/``verify``/``blank``/``erase`` emit no program pulse, so there is
-    nothing to override.
+    --pulse-us overrides the database program-pulse width for this run only, in
+    the range 1..65535 microseconds. Out-of-range values are refused before the
+    port is opened. A value above 50000 is refused by the firmware on protocol
+    0x0B before any high voltage is enabled. Using the flag always reports both
+    the database pulse and the override, so a log captured without its command
+    line still records which pulse was used.
   
   Options:
     -b, --no-blank-check      Skip the blank check before write (erase still

--- a/tests/test_chip_test.py
+++ b/tests/test_chip_test.py
@@ -627,9 +627,9 @@ def test_derive_plan_destructive_flag_strips_not_annotates():
         "M8720 is REFUSE -- its six SDP-leg steps must all be unsupported/NA"
     )
     assert plan_default.locked_destructive == [
-        (OP_WRITE, 'write_scope="none": write omitted (D-01)'),
-        (OP_VERIFY, 'write_scope="none": verify omitted (D-01)'),
-        (OP_ERASE, 'write_scope="none": erase omitted (D-01)'),
+        (OP_WRITE, 'write_scope="none": write omitted'),
+        (OP_VERIFY, 'write_scope="none": verify omitted'),
+        (OP_ERASE, 'write_scope="none": erase omitted'),
     ]
     assert plan_destructive.locked_destructive == []
     ops_default_set = set(ops_default)

--- a/tests/test_chip_test_sdp_leg.py
+++ b/tests/test_chip_test_sdp_leg.py
@@ -2117,9 +2117,9 @@ def test_refuse_write_scope_none_is_byte_identical_to_pre_phase134():
     plan = derive_plan(name, _REAL_DB, write_scope="none")
     assert [s.op for s in plan.steps] == ["id", "read", "blank-check"]
     assert plan.locked_destructive == [
-        (OP_WRITE, 'write_scope="none": write omitted (D-01)'),
-        (OP_VERIFY, 'write_scope="none": verify omitted (D-01)'),
-        (OP_ERASE, 'write_scope="none": erase omitted (D-01)'),
+        (OP_WRITE, 'write_scope="none": write omitted'),
+        (OP_VERIFY, 'write_scope="none": verify omitted'),
+        (OP_ERASE, 'write_scope="none": erase omitted'),
     ]
 
 

--- a/tests/test_py32_packaging.py
+++ b/tests/test_py32_packaging.py
@@ -68,8 +68,6 @@ _REQUIREMENT_RE = re.compile(r'"([^"]*)"')
 # proximity-checked phrase below.
 _D17_PHRASES = (
     "accepted deviation",
-    "D-17",
-    "HOST-01",
     "_install_with_avrdude",
     "avrdude-mcu-detection-fallback",
 )

--- a/tools/audit_coverage_matrix.py
+++ b/tools/audit_coverage_matrix.py
@@ -1,5 +1,5 @@
 """
-Phase 11 — Coverage Matrix & DB Inconsistency Audit (Wave 1 — tool skeleton).
+Coverage Matrix & DB Inconsistency Audit.
 
 Emits `.planning/v1.3-COVERAGE-MATRIX.md`: a single-source coverage map of
 every algorithm-0x07 (28-pin DIP CMOS UV-EPROM) and algorithm-0x08 (32-pin
@@ -22,11 +22,11 @@ Output defaults to `<repo-root>/.planning/v1.3-COVERAGE-MATRIX.md` (absolute,
 computed from `__file__` per RESEARCH.md Pitfall 6 — robust against the
 operator's cwd).
 
-Exit codes (D-03):
+Exit codes:
   0 — clean generate, or `--check` with no new findings.
   1 — `--check` would mint a new DEFECT-COV-NN, OR DB parse error.
 
-Idempotence contract (D-02 / Pattern B):
+Idempotence contract:
   - Sorted iteration on every dict.items()
   - No timestamps in output (no datetime.now())
   - Path.write_text(..., encoding="utf-8", newline="\\n")
@@ -45,7 +45,7 @@ from pathlib import Path
 
 from firestarter.database import EpromDatabase  # noqa: F401 — singleton kept available for §3/§4 lookups
 
-# Module-top path constants (lifted verbatim from check_dispatch.py:23-30 per D-01).
+# Module-top path constants (lifted verbatim from check_dispatch.py).
 _DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "firestarter", "data")
 DB_FILE = os.environ.get(
     "FIRESTARTER_DB_FILE",
@@ -104,7 +104,7 @@ def iter_all_rows(db_raw):
 
 
 def pulse_bucket(us):
-    """D-09 bucketing: microseconds-integer input → label string."""
+    """Pulse bucketing: microseconds-integer input → label string."""
     if us < 100:
         return "< 100 us"
     if us < 1000:
@@ -135,13 +135,13 @@ def size_label(size_bytes):
 
 
 # ---------------------------------------------------------------------------
-# BENCH chip map (D-11) — verbatim from REQUIREMENTS.md §BENCH lines 14-19
+# BENCH chip map
 # ---------------------------------------------------------------------------
 #
 # BENCH-01..06 are the six bench chips that v1.3 milestone close cites as the
 # receipt that the algo-0x07 + algo-0x08 families generalize across the 339
-# in-scope DB rows. BENCH-05 and BENCH-06 are candidate-pending — Phase 12
-# CONTEXT.md owns the actual selection decision (D-11). Phase 11's matrix
+# in-scope DB rows. BENCH-05 and BENCH-06 are candidate-pending — the
+# selection decision is owned elsewhere. This matrix
 # records the candidate set neutrally and does NOT propose a swap.
 #
 # Per-chip fields:
@@ -156,7 +156,7 @@ def size_label(size_bytes):
 #               when the chip is "candidate" and no concrete DB row name
 #               is matched).
 #   selection_pending: True for BENCH-05 / BENCH-06 — marks the chip as
-#                      candidate until Phase 12 selects one of the names.
+#                      candidate until one of the names is selected.
 
 BENCH_CHIP_MAP = [
     {
@@ -430,7 +430,7 @@ def emit_summary(summary, severity_counts=None):
     parts.append(md_table(["Algorithm", "True", "False"], cid_rows))
     parts.append("")
 
-    # h. Severity-tier counts (D-12) — populated by Wave 3 detection pass.
+    # h. Severity-tier counts — populated by the detection pass.
     parts.append("### Severity-tier finding counts (D-12)")
     parts.append("")
     if severity_counts is None:
@@ -453,7 +453,7 @@ def emit_summary(summary, severity_counts=None):
 
 
 def _pulse_bucket_sort_key(bucket):
-    """Sort pulse buckets in ascending magnitude (matches D-09 order)."""
+    """Sort pulse buckets in ascending magnitude."""
     order = {
         "< 100 us": 0,
         "100-999 us": 1,
@@ -470,11 +470,11 @@ def _pulse_bucket_sort_key(bucket):
 
 
 def sort_key(mfg, chip):
-    """Pattern F (PATTERNS.md lines 593-601 + RESEARCH.md 564-575) — D-06 sort.
+    """Canonical row sort.
 
     Returns the 5-tuple `(algorithm, pinout, size_bytes, manufacturer,
     first_alias)` used to order every §3 + §5 enumeration. The first_alias
-    is the leading comma-delimited variant in `part_number` (per D-06: rows
+    is the leading comma-delimited variant in `part_number` (rows
     cover the variant set verbatim, but sort by the first alias).
 
     This tuple is the load-bearing contract for byte-identical re-runs
@@ -490,7 +490,7 @@ def sort_key(mfg, chip):
 
 
 # ---------------------------------------------------------------------------
-# §3 — Full Enumeration (per-algorithm sub-tables, D-06 sort)
+# §3 — Full Enumeration (per-algorithm sub-tables)
 # ---------------------------------------------------------------------------
 
 _ENUM_HEADERS = [
@@ -540,7 +540,7 @@ def emit_full_enumeration(rows):
 
     Split into two per-algorithm sub-tables (CONTEXT.md "Claude's Discretion"
     + PATTERNS.md "Multi-table-stacked layout"): algo-0x07 first, then
-    algo-0x08. Rows within each sub-table are sorted by Pattern F (D-06).
+    algo-0x08. Rows within each sub-table use the canonical sort.
 
     `rows` is a list of (mfg, chip) tuples from `iter_in_scope_rows`.
     """
@@ -594,7 +594,7 @@ def emit_full_enumeration(rows):
 def emit_reconciliation(summary):
     """Return the §2 markdown block as a single string.
 
-    Per D-08, §2 is regenerated from live DB on every run so future DB
+    §2 is regenerated from live DB on every run so future DB
     regenerations keep §2 honest.
     """
     parts = ["## §2: DB Count Reconciliation", ""]
@@ -669,14 +669,14 @@ def emit_reconciliation(summary):
 
 
 # ---------------------------------------------------------------------------
-# §4 — Defect findings: hashing, ledger, detection, emit (Wave 3 / Plan 11-04)
+# §4 — Defect findings: hashing, ledger, detection, emit
 # ---------------------------------------------------------------------------
 #
 # Pattern C (PATTERNS.md "Stable defect-ID hash composition" + RESEARCH.md
 # Pattern 4 lines 195-218): every finding has a deterministic 16-hex hash of
 # its (severity, axis, signature) tuple. The hash → DEFECT-COV-NN mapping is
 # persisted in `.planning/v1.3-defect-coverage-ids.json` so IDs survive DB
-# regenerations (D-13 stable identity contract).
+# regenerations (stable identity contract).
 
 
 def finding_hash(severity, axis, signature):
@@ -686,7 +686,7 @@ def finding_hash(severity, axis, signature):
     (sort_keys=True, compact separators) of `{severity, axis, signature}`,
     truncated to 16 hex chars. Truncation is intentional — 16 hex = 64 bits
     of state, more than enough to avoid collisions across the < 100 expected
-    findings while keeping rendered IDs readable (D-13).
+    findings while keeping rendered IDs readable.
 
     `signature` may be a tuple or list; it is coerced to a list for JSON
     serializability (tuples are not JSON-native).
@@ -742,9 +742,9 @@ def mint_or_reuse(ledger, severity, axis, signature, next_n_holder):
 
 
 def detect_resolved_baseline(ledger, next_n_holder):
-    """Seed `DEFECT-COV-00` into the ledger if absent (D-15 RESOLVED baseline).
+    """Seed `DEFECT-COV-00` into the ledger if absent (RESOLVED baseline).
 
-    DEFECT-COV-00 is the v1.0 Phase 13 WARNING-5 override — the
+    DEFECT-COV-00 is the v1.0 WARNING-5 override — the
     `DIP28_2764` HAZARD that was caught and fixed in v1.0. Including it
     in the ledger makes the matrix's §4 narrative complete (the audit
     starts from the last known-good state) and reserves NN=00 forever so
@@ -859,7 +859,7 @@ def detect_correctness(rows):
 
         # One finding per (algo, pinout, size, manufacturer, first_alias) outlier
         # so multi-manufacturer clusters split into per-manufacturer findings
-        # per D-14 signature schema.
+        # per the signature schema.
         per_sig = defaultdict(list)
         for mfg, chip in outlier_rows:
             first_alias = chip["part_number"].split(",")[0]
@@ -897,7 +897,7 @@ def detect_correctness(rows):
 def detect_variance(rows):
     """Yield VARIANCE findings: chip_id_check toggles + chip_id_value drift.
 
-    Per D-14 signature schema, group by (algorithm, pinout, size_bytes,
+    Per the signature schema, group by (algorithm, pinout, size_bytes,
     manufacturer). Two axes:
       (a) chip_id_check_toggle — different members of a cluster have
           different `chip_id_check` boolean values
@@ -985,7 +985,7 @@ def emit_defects(findings, ledger, next_n_holder):
     """Render §4 as a list of markdown lines.
 
     Order: DEFECT-COV-00 RESOLVED baseline first, then HAZARD, then
-    CORRECTNESS, then VARIANCE (D-12 severity-tier order). Within each
+    CORRECTNESS, then VARIANCE (severity-tier order). Within each
     tier, sort by finding hash ascending for stable output.
     """
     lines = ["## §4: DB Inconsistencies / Defect Candidates", ""]
@@ -999,7 +999,7 @@ def emit_defects(findings, ledger, next_n_holder):
     )
     lines.append("")
 
-    # DEFECT-COV-00 RESOLVED block (D-15).
+    # DEFECT-COV-00 RESOLVED block.
     lines.append("### DEFECT-COV-00 — RESOLVED in v1.0 Phase 13 (WARNING-5)")
     lines.append("")
     lines.append(
@@ -1072,17 +1072,17 @@ def emit_defects(findings, ledger, next_n_holder):
 
 
 # ---------------------------------------------------------------------------
-# §5 — BENCH Coverage Proof (D-09 / D-10 / D-11)
+# §5 — BENCH Coverage Proof
 # ---------------------------------------------------------------------------
 #
-# Three per-axis coverage tables (D-09) demonstrate that BENCH-01..06 cover
+# Three per-axis coverage tables demonstrate that BENCH-01..06 cover
 # the algo-0x07 + algo-0x08 family across the axes that matter: pinout-class,
 # pulse-duration bucket, size bucket. Uncovered cells cross-reference §4
-# DEFECT-COV-NN findings where the gap is structural (D-10); deliberate gaps
+# DEFECT-COV-NN findings where the gap is structural; deliberate gaps
 # are listed in the Known Gaps subsection.
 #
 # Forbids proposing alternative BENCH chip selections — BENCH-05 /
-# BENCH-06 stay "candidate" until CONTEXT.md decides.
+# BENCH-06 stay "candidate" until the selection is made.
 
 
 def _findings_for_pinout(findings, ledger, pinout):
@@ -1194,7 +1194,7 @@ def pulse_coverage(rows, findings, ledger, algo):
         bench_bucket_map[b["id"]] = bench_buckets(b)
 
     table_rows = []
-    # Iterate D-09 bucket order over the union of seen + pre-declared buckets.
+    # Iterate bucket order over the union of seen + pre-declared buckets.
     seen = sorted(bucket_rows, key=_pulse_bucket_sort_key)
     for bucket in seen:
         members = bucket_rows[bucket]
@@ -1282,9 +1282,9 @@ def size_coverage(rows, findings, ledger, algo):
 def emit_bench_coverage(rows, findings, ledger):
     """Return §5 as a single markdown string.
 
-    Three per-axis tables (D-09) + Known Gaps subsection (D-10) + milestone-
-    claim closing prose. BENCH chip selection is observational only — D-11
-    forbids swap proposals; BENCH-05 / BENCH-06 stay "candidate".
+    Three per-axis tables + Known Gaps subsection + milestone-claim closing
+    prose. BENCH chip selection is observational only — swap proposals are
+    forbidden; BENCH-05 / BENCH-06 stay "candidate".
     """
     in_scope_count = len(rows)
     parts = ["## §5: BENCH Coverage Proof", ""]
@@ -1366,7 +1366,7 @@ def emit_bench_coverage(rows, findings, ledger):
     )
     parts.append("")
 
-    # Known Gaps subsection (D-10)
+    # Known Gaps subsection
     parts.append("### Known Gaps")
     parts.append("")
     parts.append(
@@ -1457,7 +1457,7 @@ def generate_matrix(output, ledger_path, check=False):
         return 1
 
     # Run detection pass: gather all findings BEFORE deciding to mint or
-    # check. This keeps --check semantics dry-run (D-03).
+    # check. This keeps --check semantics dry-run.
     findings = (
         list(detect_hazard(rows))
         + list(detect_correctness(rows))
@@ -1465,10 +1465,10 @@ def generate_matrix(output, ledger_path, check=False):
     )
 
     # Severity-tier counts for §1 (live detection only — DEFECT-COV-00 is
-    # excluded as a static RESOLVED entry per D-15).
+    # excluded as a static RESOLVED entry).
     severity_counts = Counter(f["severity"] for f in findings)
 
-    # --check semantics (D-03): dry-run drift gate.
+    # --check semantics: dry-run drift gate.
     # 1. Seed the RESOLVED baseline into a copy of the on-disk ledger.
     # 2. Compute hash for each detected finding; if any hash is absent from
     #    that ledger (including the post-seed baseline), exit 1.
@@ -1578,7 +1578,7 @@ def _algo_label(algo):
 def _group_rows_by_algo(rows):
     """Group rows into a dict[algo_int -> sorted list of (mfg, chip)].
 
-    Sort within each algo by the Pattern F (D-06) 5-tuple so output is
+    Sort within each algo by the canonical 5-tuple so output is
     deterministic. The outer dict is iterated via sorted(keys) at emit time.
     """
     groups = defaultdict(list)
@@ -1706,7 +1706,7 @@ def _members_with_parseable_pulse(members):
     self-time internally — 355 rows across 8 algos in the current DB), where
     `0` means algorithm-controlled rather than unparseable — true by
     construction because `interpret_timing` (build_db.py) makes a decode
-    fault fatal (D-08). `detect_correctness` compares pulse magnitudes and so
+    fault fatal. `detect_correctness` compares pulse magnitudes and so
     cannot meaningfully operate on those algorithm-controlled rows.
     """
     return [
@@ -1806,7 +1806,7 @@ def generate_matrix_all(output, ledger_path, check=False):
         print(f"ERROR: ledger {ledger_path} parse failed: {exc}", file=sys.stderr)
         return 1
 
-    # Detection pass per-algo for dry-run drift gate (D-03 semantics).
+    # Detection pass per-algo for the dry-run drift gate.
     all_findings = []
     for algo in sorted(groups):
         members = groups[algo]

--- a/tools/build_db.py
+++ b/tools/build_db.py
@@ -12,7 +12,7 @@ from firestarter.constants import MAX_27C020_SIZE
 # ==========================================
 # Pinned to the SHA recorded in tools/DECODE-NOTES.md §0/§3 (the Phase-86 regen
 # provenance of record) so the fetch is deterministic and the baseline re-pin is
-# reproducible. Was /-/raw/master/ — switched to the pinned commit per D-05
+# reproducible. Was /-/raw/master/ — switched to the pinned commit
 # discretion (DECODE-NOTES.md §3). Short form: a8efaedc.
 MINIPRO_XML_URL = (
     "https://gitlab.com/DavidGriffith/minipro/-/raw/"
@@ -21,7 +21,7 @@ MINIPRO_XML_URL = (
 _DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "firestarter", "data")
 OUTPUT_FILE = os.path.join(_DATA_DIR, "chip_database.json")
 PINOUT_FILE = os.path.join(_DATA_DIR, "pinouts.json")
-# VAR-05 / D-10: curated non-upstream chip supplement, merged post-decode (see
+# Curated non-upstream chip supplement, merged post-decode (see
 # the EXTRA_CHIPS block in main()). Physically-real chips absent from infoic.xml.
 EXTRA_CHIPS_FILE = os.path.join(os.path.dirname(__file__), "extra_chips.json")
 # Largest 0x08 32-pin part where pin 31 (A18) is structurally unused, so the
@@ -126,12 +126,12 @@ _PAGE_SIZE_BY_PART: dict[str, int] = {
     # discipline. The shared entry gets W29C020's citation via part-number lookup.
 }
 
-# CR-01 Option A (Phase 66 gap-closure): algorithm sentinel for non-supported chips.
+# Algorithm sentinel for non-supported chips.
 # dispatch(0x00, None) falls into the mem_type fallback chain (protocol==0 path):
 #   _ALGO_MEM_TYPE.get(0x00) → None → {1:..., 4:..., 3:..., 5:...}.get(None, "ERROR")
 #   → "ERROR"
 # No real handler (configure_eprom / configure_eeprom28c / configure_flash* /
-# configure_sram) is ever reached for a non-supported chip. D-03 HARD: do NOT
+# configure_sram) is ever reached for a non-supported chip. HARD: do NOT
 # route any flagged chip to a working handler.
 NON_DISPATCHABLE_ALGO = 0x00
 
@@ -375,7 +375,7 @@ def classify(type_int, proto_id, pm_idx, flags, pinout_key, mem_size):
 def interpret_timing(raw_hex, protocol_id):
     # [VERIFIED: minipro database.c#L866 @ a8efaedc]
     # Raw pulse_delay is microseconds for ALL protocols — no multiplier.
-    # Contract (D-08, Phase 148 Plan 03): returns an int, always microseconds.
+    # Contract: returns an int, always microseconds.
     # `0` means "algorithm-controlled" (protocols that do not consume
     # pulse-delay) -- an unparseable pulse_delay on a protocol that DOES
     # consume it (0x07/0x08/0x0B) is fatal, not a silent 0, so that sentinel
@@ -485,7 +485,7 @@ def main():
                 if proto_id == 0x34:
                     _support_status = "protocol-not-implemented"
                     # DB-04 Approach A (67.1-01): reason string begins with SC-required
-                    # wording so the host can render it verbatim (Plan 02 prints f"{e}").
+                    # wording so the host can render it verbatim.
                     # Must contain "not implemented" substring — existing test
                     # test_read_protocol_not_implemented_typed_refusal asserts it.
                     _unsupported_reason = (
@@ -527,7 +527,7 @@ def main():
                         file=sys.stderr,
                     )
                     # CR-01 Option A: demote to NON_DISPATCHABLE_ALGO so dispatch()
-                    # returns ERROR instead of configure_eprom (D-03 HARD invariant).
+                    # returns ERROR instead of configure_eprom (HARD invariant).
                     proto_id = NON_DISPATCHABLE_ALGO
 
                 # AT28C04/AT28C16 family. Runs after the guard above so its reason
@@ -571,7 +571,7 @@ def main():
 
                 # --- SYNTHESIZE "COMPLETE" DATA ---
 
-                # Step 1: Resolve pinout key (principled — D-02/D-03)
+                # Step 1: Resolve pinout key (principled)
                 pinout_key = resolve_pinout_key(
                     pin_count,
                     variant,
@@ -582,9 +582,9 @@ def main():
                     mem_size=mem_size,
                 )
 
-                # Step 2: D-06 fail-safe — skip unclassifiable chips entirely.
+                # Step 2: fail-safe — skip unclassifiable chips entirely.
                 # No VPP-asserting dispatch is ever emitted for an uncertain chip.
-                # Replaces the old hardcoded 24-pin safety-skip (D-05).
+                # Replaces the old hardcoded 24-pin safety-skip.
                 if pinout_key is None:
                     print(
                         f"WARN: skipping {mfg_name}/{name} — unclassifiable pinout "
@@ -633,21 +633,21 @@ def main():
                         _support_status = "vpp-exceeds-max"
                         # DB-04 Approach A (67.1-01): reason string begins with
                         # "VPP <x>V exceeds programmer max (<ceil>V)" so the host
-                        # can render it verbatim (Plan 02 prints f"{e}").
+                        # can render it verbatim.
                         # Uses "programmer max" (not "RURP ceiling") per SC#2 wording.
                         _unsupported_reason = (
                             f"VPP {_nmos_vpp_mv // 1000}V exceeds programmer max "
                             f"({RURP_VPP_CEILING_MV // 1000}V)"
                         )
                         # CR-01 Option A: demote to NON_DISPATCHABLE_ALGO so dispatch()
-                        # returns ERROR instead of configure_eprom (D-03 HARD invariant).
+                        # returns ERROR instead of configure_eprom (HARD invariant).
                         proto_id = NON_DISPATCHABLE_ALGO
                     # else: leave _support_status as "supported" — M2732A (21V)
                     # is within the RURP ceiling.
 
                 # Canonical part-number key (first alias, @PACKAGE suffix
                 # stripped) — hoisted here because the page_size emit arm
-                # below (PGSZ-01, Phase 149) needs it in both its lookup and
+                # below needs it in both its lookup and
                 # its guard condition; previously recomputed twice inline.
                 _canon = name.split(",")[0].split("@")[0].strip()
 

--- a/tools/catalog/codegen_vectors.py
+++ b/tools/catalog/codegen_vectors.py
@@ -22,9 +22,9 @@ Validation (--check): validates the catalog and exits 0/1 without writing
 files. Must not require [[messages]] — this catalog uses [[vectors]].
 
 This script is SEPARATE from codegen.py to avoid entangling the [[messages]]
-validator with the [[vectors]] schema (RESEARCH Open Q3 + Pitfall 6, Phase 52).
+validator with the [[vectors]] schema.
 The host sub-repo keeps a byte-identical copy at
-firestarter_app/tools/catalog/codegen_vectors.py (D-04/D-09).
+firestarter_app/tools/catalog/codegen_vectors.py.
 
 Stdlib only (Python 3.11+ for tomllib).
 """
@@ -42,7 +42,7 @@ from pathlib import Path
 VECTOR_NAME_RE = re.compile(r"^VEC_[A-Z0-9][A-Z0-9_]*$")
 
 # Max payload / frame sizes for the C++ struct array dimensions.
-# Sized to the largest D-05 corpus member: 1024-byte payload, 1031-byte frame.
+# Sized to the largest corpus member: 1024-byte payload, 1031-byte frame.
 MAX_PAYLOAD_LEN = 1024
 MAX_FRAME_LEN   = 1031
 

--- a/tools/check_devtest_orchestrator.py
+++ b/tools/check_devtest_orchestrator.py
@@ -1,5 +1,5 @@
 """
-AST-based orchestrator-only gate for `dev test` (SAFE-03, Phase 109 D-02/D-03).
+AST-based orchestrator-only gate for `dev test`.
 
 Scans `firestarter/chip_test.py` (the Phase-108 test-plan engine),
 `firestarter/cli_handlers.py` (the `dev_test` handler, scoped), and
@@ -22,7 +22,7 @@ orchestrator-only contract:
      `chip_resolver.resolve_chip` + `database.convert_to_programmer` only.
   3. `force=True` keyword pass-through, or any `"--force"` string literal.
      `dev test` never forces past a firmware/host refusal.
-  4. Broad exception handlers (Phase 133 D-09/D-14) -- a bare `except:`, an
+  4. Broad exception handlers -- a bare `except:`, an
      `except Exception:`, an `except BaseException:`, or a tuple containing
      either. Bare `except:` is already caught by ruff's E722, but
      `except Exception:`/`except BaseException:` are caught by NOTHING in
@@ -30,7 +30,7 @@ orchestrator-only contract:
      (`["E", "F", "I", "UP"]`), so the `# noqa: BLE001` already sitting on
      `chip_test.py`'s `_sample` sampler handler is INERT. This bucket carries
      one narrow, reasoned exemption for that pre-existing handler
-     (`_BROAD_EXCEPT_EXEMPTIONS`, D-14) -- a best-effort diagnostic hook
+     (`_BROAD_EXCEPT_EXEMPTIONS`) -- a best-effort diagnostic hook
      invoked with an opaque caller-supplied callable, never a blanket
      allowance for the broad form.
 
@@ -42,22 +42,22 @@ implicit.
 
 This is a genuinely-populated AST walk (`ast.parse` + a fresh
 `ast.NodeVisitor`), NOT a hollow declared-empty detector -- the exact
-tech-debt fate this project incurred with v1.12's GATE-03 (a checker that
+tech-debt fate this project incurred with an earlier gate (a checker that
 could never fail because it asserted nothing concrete). The paired pytest
 (`tests/test_check_devtest_orchestrator.py`) proves this checker actually
 flips to non-zero on a planted violation, injected via the
 `FIRESTARTER_DEVTEST_SRC` / `FIRESTARTER_DEVTEST_HANDLER` env-overrides below
-(mirrors `tools/check_dispatch.py`'s `FIRESTARTER_DB_FILE` seam) -- D-03's
+(mirrors `tools/check_dispatch.py`'s `FIRESTARTER_DB_FILE` seam) -- the
 anti-hollow contract.
 
-Handler scan (Phase 112): the `@dev.command("test")` CLI handler landed as a
+Handler scan: the `@dev.command("test")` CLI handler landed as a
 function inside `firestarter/cli_handlers.py` (a sibling of
 `dev_validate_family`), not a standalone module of its own.
 `FIRESTARTER_DEVTEST_HANDLER` (default: `_DEFAULT_DEVTEST_HANDLER`) points at
 the real `cli_handlers.py` file and this checker actually scans it -- but
 `cli_handlers.py` is a large, pre-existing multi-command module with 10
 pre-existing, legitimate `-f`/`--force` flags on UNRELATED commands (`read`,
-`write`, `verify`, `blank`, `erase`, `id`) that long predate Phase 112 and
+`write`, `verify`, `blank`, `erase`, `id`) that long predate it and
 are outside this handler's contract entirely. Scanning the WHOLE file would
 make the gate permanently red on code this phase never touched -- a false
 positive, not a real violation. Instead, `_scan_target_functions` narrows
@@ -68,8 +68,8 @@ exactly the new Phase-112 code, via an AST `FunctionDef`/`AsyncFunctionDef`
 name filter over the parsed module -- never a brittle line-number range. The
 `chip_test.py` leg is unaffected and still scans the ENTIRE file (it has, by
 construction, zero pre-existing `--force` usage). A handler that exists on
-disk but is silently skipped by this checker is the v1.12 hollow-GATE-03
-failure mode (Phase 109 D-02/D-03) -- the missing-file tolerance in
+disk but is silently skipped by this checker is the hollow-checker
+failure mode -- the missing-file tolerance in
 `_scan_file` stays only for a nonexistent test-fixture path, never for the
 real handler target, and `_scan_target_functions` still fails closed if
 `dev_test` itself is ever renamed/removed without updating this checker.
@@ -96,7 +96,7 @@ _DEFAULT_CHIP_TEST = os.path.join(_HERE, "..", "firestarter", "chip_test.py")
 
 # Env-override seam (mirrors check_dispatch.py's FIRESTARTER_DB_FILE): lets
 # the paired pytest point this checker at a deliberately-violating fixture
-# file without editing the real, clean chip_test.py source (D-03).
+# file without editing the real, clean chip_test.py source.
 FIRESTARTER_DEVTEST_SRC = os.environ.get("FIRESTARTER_DEVTEST_SRC", _DEFAULT_CHIP_TEST)
 
 # The Phase-112 `@dev.command("test")` CLI handler -- lands as a function
@@ -165,7 +165,7 @@ _HANDLER_FUNCTION_NAMES = frozenset(
 )
 
 # ---------------------------------------------------------------------------
-# Deny-list vocabularies (D-02)
+# Deny-list vocabularies
 # ---------------------------------------------------------------------------
 
 # VPP-set call sites: attribute/function names that set or enable VPP. There
@@ -208,7 +208,7 @@ _FORCE_KEYWORD_NAME = "force"
 _FORCE_CLI_FLAG = "--force"
 
 # ---------------------------------------------------------------------------
-# Broad-except deny bucket (Phase 133 D-09/D-14)
+# Broad-except deny bucket
 # ---------------------------------------------------------------------------
 #
 # Bare `except:` is already caught by ruff's E722 (this repo's `select` is
@@ -222,7 +222,7 @@ _FORCE_CLI_FLAG = "--force"
 # check.
 _BROAD_EXCEPT_NAMES = frozenset({"Exception", "BaseException"})
 
-# (file basename, enclosing function name) -> non-empty reason (D-14).
+# (file basename, enclosing function name) -> non-empty reason.
 #
 # Follows the house frozenset/name-map-with-rationale idiom
 # (`_HANDLER_FUNCTION_NAMES` above is the in-file precedent;
@@ -241,7 +241,7 @@ _BROAD_EXCEPT_NAMES = frozenset({"Exception", "BaseException"})
 # swallow-all behaviour is its documented contract (see `_sample`'s own
 # docstring), and `_make_sampler` (firestarter/cli_handlers.py) is live in
 # production. Narrowing the handler instead of exempting it would change
-# shipped production behaviour, which criterion 4 of Phase 133 forbids.
+# shipped production behaviour, which is forbidden.
 _BROAD_EXCEPT_EXEMPTIONS: dict[tuple[str, str], str] = {
     (os.path.basename(_DEFAULT_CHIP_TEST), "_sample"): (
         "D-14: _sample (firestarter/chip_test.py) is a best-effort "
@@ -327,7 +327,7 @@ def _stale_exemption_row_violations(
 
 
 class _OrchestratorDenyVisitor(ast.NodeVisitor):
-    """Walk a chip_test.py-shaped AST, collecting SAFE-03 deny-list hits.
+    """Walk a chip_test.py-shaped AST, collecting deny-list hits.
 
     Populates four violation buckets during a single tree walk:
       - `vpp_set_violations`: `ast.Call` sites whose callee name/attribute is
@@ -339,7 +339,7 @@ class _OrchestratorDenyVisitor(ast.NodeVisitor):
       - `broad_except_violations`: a bare `except:`, an `except Exception:`,
         an `except BaseException:`, or a tuple containing either -- unless
         the innermost enclosing function is exempted by
-        `_BROAD_EXCEPT_EXEMPTIONS` (D-14).
+        `_BROAD_EXCEPT_EXEMPTIONS`.
 
     Each violation is recorded as a human-readable `"line N: ..."` string so
     `main()` can print an actionable per-bucket FAIL: summary.
@@ -351,7 +351,7 @@ class _OrchestratorDenyVisitor(ast.NodeVisitor):
         self.raw_wire_dict_violations: list[str] = []
         self.force_violations: list[str] = []
         self.broad_except_violations: list[str] = []
-        # Enclosing-function-name stack (D-09) -- exists ONLY so
+        # Enclosing-function-name stack -- exists ONLY so
         # `visit_ExceptHandler` can consult a (file, function) exemption.
         # Empty when the current node sits at module level.
         self._function_stack: list[str] = []
@@ -479,7 +479,7 @@ def _scan_target_functions(
     `function_names` -- the latter is deliberately treated as "nothing to
     scan" rather than a silent empty-pass, so `main()`'s scanned-empty
     fail-closed guard still fires if `dev_test` (or its helpers) is ever
-    renamed/removed here without updating `_HANDLER_FUNCTION_NAMES` (D-02/D-03
+    renamed/removed here without updating `_HANDLER_FUNCTION_NAMES` (
     anti-hollow: a scoped scan that quietly matches zero functions is exactly
     as hollow as skipping the file outright).
 
@@ -510,7 +510,7 @@ def _scan_target_functions(
 
 
 def _assert_host_only(path: str) -> str | None:
-    """Assert `path` does not resolve into the firmware sub-repo (D-02).
+    """Assert `path` does not resolve into the firmware sub-repo.
 
     Returns an error string if the resolved path falls inside the sibling
     `firestarter/` firmware submodule (a peer of `firestarter_app/` in the
@@ -561,7 +561,7 @@ def main() -> None:
     updating this checker.
 
     Guard (a) runs FIRST, before any scanning: an exemption table with an
-    empty or missing reason fails the build immediately (Phase 133 D-14).
+    empty or missing reason fails the build immediately.
     Guard (b) -- the stale-row check -- runs AFTER scanning, over the files
     actually found, because it needs their parsed source.
     """

--- a/tools/check_diagnostic_report_claims.py
+++ b/tools/check_diagnostic_report_claims.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """AST-based string-literal claim scanner over `firestarter/diagnostic_report.py`
-(CLOSE-03, v1.30 Phase 137 plan 137-02).
+.
 
 Purpose: `diagnostic_report.py`'s string literals are the `dev test`
 diagnostic report text that reaches a stranger's terminal on every single
@@ -39,7 +39,7 @@ constant set matches the donor byte-for-byte; it is intentionally unused by
 `firestarter/cli_handlers.py` used to carry two named SDP recovery-string
 constants (`_SDP_RECOVERY_LOUD` / `_SDP_RECOVERY_NEUTRAL`) with their own
 committed, scoped wording gate (`tests/test_sdp_recovery_wording.py`, v1.30
-Phase 134 plan 134-09, LEG-14) -- quick task 260821-spg deleted the console
+) -- a later change deleted the console
 echo those constants fed, the constants themselves, and that gate along with
 them, so there is no longer a second scanned surface for this checker to
 defer to. The scan target here remains exactly `diagnostic_report.py`; this
@@ -102,7 +102,7 @@ FIRESTARTER_DIAGREPORT_SRC = os.environ.get(
 # ---------------------------------------------------------------------------
 
 FORBIDDEN_PATTERNS = [
-    # -- forked verbatim from Phase 122's check_permitted_claims.py (via plan 137-01) --
+    # -- forked verbatim from check_permitted_claims.py --
     ("verified-fixed", re.compile(r"verified\s+fixed", re.IGNORECASE)),
     ("confirmed-working", re.compile(r"confirmed\s+working", re.IGNORECASE)),
     ("silicon-verified", re.compile(r"silicon[-\s]verified", re.IGNORECASE)),

--- a/tools/check_dispatch.py
+++ b/tools/check_dispatch.py
@@ -1,6 +1,6 @@
 """
 Regression scan: assert every chip in chip_database.json reaches a real
-firmware dispatch path after Phase 12.
+firmware dispatch path.
 
 Mirrors the post-Phase-12 dispatch order documented in
 firestarter/src/proms/memory.cpp::configure_memory and the algorithm→mem_type
@@ -34,7 +34,7 @@ PINOUTS_FILE = os.environ.get(
 
 # Algorithm integer (upstream protocol_id from infoic.xml) → firmware mem_type integer.
 # Must mirror firestarter_app/firestarter/database.py::_ALGO_MEM_TYPE
-# (lands in Plan 03 per CONTEXT.md D3).
+# (lands later).
 _ALGO_MEM_TYPE = {
     0x05: 5,  # FLASH_AMD_STD     → TYPE_FLASH_TYPE_4
     0x06: 3,  # FLASH_AMD_ALT     → TYPE_FLASH_TYPE_3
@@ -54,7 +54,7 @@ _ALGO_MEM_TYPE = {
 # enables the VPP boost regulator on a 5V SRAM part).
 _SRAM_PROTOCOLS = {0x0E, 0x27, 0x28, 0x29}
 
-# Per-family VPP range invariants (Phase 71 HARN-04 / D-09).
+# Per-family VPP range invariants.
 # Maps handler name → (min_vpp_mv, max_vpp_mv).
 #
 # IMPLEMENTATION NOTE: chip_database.json stores vpp_mv in the "electrical" block.
@@ -76,7 +76,7 @@ _SRAM_PROTOCOLS = {0x0E, 0x27, 0x28, 0x29}
 # Range (0, 6000) is the semantically correct invariant for these handlers —
 # proven capable of firing on a synthetic chip with vpp_mv=12000 routed to configure_sram.
 _FAMILY_VPP_INVARIANTS: dict[str, tuple[int, int]] = {
-    "configure_eprom": (0, 25000),  # RURP VPP ceiling 25V (raised Phase 79 from 22V)
+    "configure_eprom": (0, 25000),  # RURP VPP ceiling 25V (raised from 22V)
     "configure_eeprom28c": (0, 6000),  # 5V-only EEPROM — no elevated VPP rail
     "configure_flash_nor_unlock": (
         0,
@@ -92,7 +92,7 @@ _FAMILY_VPP_INVARIANTS: dict[str, tuple[int, int]] = {
 # configure_flash_intel where the mismatch is detectable from the DB. For 5V-only
 # handlers, the DB's electrical.vpp_mv encodes WP-pin voltage (not programming VPP),
 # so checking vpp_mv > 6000 would produce false positives on every AMD/SST flash chip.
-# The 5V handler invariants are proven via synthetic fixture only (D-09).
+# The 5V handler invariants are proven via synthetic fixture only.
 _DB_CHECKED_VPP_INVARIANTS: frozenset[str] = frozenset({"configure_flash_intel"})
 
 # DIP28_2764 + Flash/EEPROM hazard guard (WARNING-5).
@@ -183,9 +183,9 @@ def main():
     # This is loaded once here and used per-chip in the scan loop below.
     no_vpp_pin_pinouts = _build_no_vpp_pin_set(PINOUTS_FILE)
 
-    # WIRE-02 (D-15 Shape A): host-side wire-emit round-trip surface.
+    # Host-side wire-emit round-trip surface.
     # Per-chip we call db.convert_to_programmer(db.get_eprom(part)) and assert
-    # the produced wire dict contains canonical "vpp_mv" (Plan 02-01 contract)
+    # the produced wire dict contains canonical "vpp_mv"
     # and never the legacy "vpp" key.
     db = EpromDatabase()
 
@@ -202,7 +202,7 @@ def main():
     pni_with_known_proto = []
     # Assertion 3: no supported chip resolves to not_implemented (enforced above
     # in the per-chip loop via the reworked not_implemented bucket — no separate list needed).
-    # SC#3 / D-03 HARD inverse guard: non-supported chip wired to a real handler is a
+    # HARD inverse guard: non-supported chip wired to a real handler is a
     # gate failure. check_dispatch previously only checked the regression direction
     # (supported → not_implemented); this bucket catches the dangerous inverse.
     non_supported_dispatchable = []
@@ -219,7 +219,7 @@ def main():
         for chip in chips:
             total += 1
             proto = chip.get("programming", {}).get("algorithm", 0) or 0
-            # Mirror database._map_data's real mem_type derivation exactly (D-12):
+            # Mirror database._map_data's real mem_type derivation exactly:
             # - When proto is a known algorithm, look it up in _ALGO_MEM_TYPE.
             # - When proto is 0 (falsy), fall through to the electrical.type string
             #   heuristic — default TYPE_EPROM(1), "Flash"->2, "SRAM"->4 — because
@@ -228,7 +228,7 @@ def main():
             # proto==0 yielded mt=None and dispatch(0, None)=ERROR (false "safe").
             # The corrected derivation makes the 4 vpp-exceeds-max UV-EPROM chips
             # (etype="UV-EPROM", proto=0) derive mt=1 -> dispatch(0,1)=configure_eprom,
-            # which is the REAL host+firmware outcome (D-12 truthfulness).
+            # which is the REAL host+firmware outcome.
             if proto and proto in _ALGO_MEM_TYPE:
                 mt = _ALGO_MEM_TYPE[proto]
             else:
@@ -256,7 +256,7 @@ def main():
                     pni_with_known_proto.append(
                         f"{mfg}/{part} proto=0x{proto:02X} — protocol IS in KNOWN_PROTOCOLS"
                     )
-                # SC#3 / D-03 HARD inverse guard + D-12 host-guard exemption (CR-02):
+                # HARD inverse guard + host-guard exemption:
                 #
                 # With the realigned _map_data-mirroring mt derivation, the 4
                 # vpp-exceeds-max UV-EPROM chips correctly derive mt=1 ->
@@ -265,10 +265,10 @@ def main():
                 #
                 # SAFETY GUARANTEE: chip_resolver.resolve_chip raises ChipNotImplementedError
                 # for EVERY chip with support_status != "supported" BEFORE any wire dict is
-                # built or serial byte emitted (D-12 / Phase 66 Plan 05).  The host guard is
+                # built or serial byte emitted. The host guard is
                 # the authoritative safety layer; the firmware trusts the wire dict.
                 #
-                # GATE ROLE (D-12 amendment): this gate is GREEN because the HOST GUARD
+                # GATE ROLE: this gate is GREEN because the HOST GUARD
                 # refuses every non-supported chip — NOT because the sim pretends mem_type
                 # is None.  The gate's job is to:
                 #   1. Model the real _map_data mem_type derivation truthfully (done above).
@@ -294,7 +294,8 @@ def main():
                     # A supported chip with no dispatch path is a real gate failure.
                     errors.append(f"{mfg}/{part} proto=0x{proto:02X} mem_type={mt}")
                 # else: non-supported chip dispatching to ERROR is the expected outcome
-                # (NON_DISPATCHABLE_ALGO=0x00 → dispatch returns ERROR; D-03 HARD enforced).
+                # (NON_DISPATCHABLE_ALGO=0x00 → dispatch returns ERROR;
+                # HARD enforced).
                 continue
             if handler == "not_implemented":
                 if chip_ss == "supported":
@@ -322,7 +323,7 @@ def main():
                     # Populate non_supported_dispatchable when this is ALSO a non-supported chip
                     # routing to a real handler with a VPP mismatch — the dangerous dual-violation:
                     # chip classification AND VPP contract are both wrong simultaneously.
-                    # This makes the inverse detector non-hollow per D-09 (proven via synthetic
+                    # This makes the inverse detector non-hollow (proven via synthetic
                     # fixture in test_check_dispatch_invariants.py).
                     if chip_ss != "supported":
                         non_supported_dispatchable.append(
@@ -361,7 +362,7 @@ def main():
                     f"{mfg}/{part} proto=0x{proto:02X} pinout={pinout}"
                 )
 
-            # WIRE-02 (D-15 Shape A): assert wire emits "vpp_mv" and no legacy
+            # Assert wire emits "vpp_mv" and no legacy
             # "vpp" for every chip. Chips not registered in EpromDatabase's
             # index (rare) skip the wire assert; the dispatch scan above still
             # covers them.

--- a/tools/check_is_memory_cmd_no_ifdef.py
+++ b/tools/check_is_memory_cmd_no_ifdef.py
@@ -1,18 +1,17 @@
 """
-LOCK-03 textual oracle: structural scan proving firmware's `is_memory_cmd()`
+Textual oracle: structural scan proving firmware's `is_memory_cmd()`
 admission predicate carries no build-configuration conditional in its body
-and enumerates exactly the expected `CMD_*` memory commands (Phase 119
-Plan 03, D-04's second half; grown from eight to nine names by Phase 151 /
-LOCK-02, which added `CMD_LOCK_STATUS`).
+and enumerates exactly the expected `CMD_*` memory commands (nine names,
+including `CMD_LOCK_STATUS`).
 
-**Why a second oracle is needed at all.** Plan 119-02 already proved
+**Why a second oracle is needed at all.** A native test already proves
 `is_memory_cmd()` *behaves* identically in two build configurations (an
 exhaustive 256-value truth table run in both `[env:native]` and the
 no-`DEV_TOOLS` `[env:native_nodevtools]`). That is a SEMANTIC proof: it can
 never distinguish "the predicate has no conditional" from "the predicate has
 a conditional whose two branches happen to agree" -- a conditional gated on
 some OTHER macro (not `DEV_TOOLS`) could pass that truth table vacuously
-while still defeating D-02's intent. This checker is the TEXTUAL oracle D-04
+while still defeating that intent. This checker is the TEXTUAL oracle
 demands: it reads the predicate's actual source text and asserts the absence
 of any preprocessor conditional, independent of what the predicate computes.
 
@@ -23,7 +22,7 @@ is_memory_cmd(uint8_t cmd)` definition and asserts BOTH:
       `#else`, `#endif`) appears inside the predicate's body. Every kind of
       conditional is checked, not only ones naming `DEV_TOOLS` -- a narrower
       check would be evadable by conditioning on a different macro, which
-      would defeat D-02's purpose just as completely.
+      would defeat the same purpose just as completely.
   (b) The body's `CMD_*` identifiers, as a SET, equal exactly the frozen
       nine-name expected set (`_EXPECTED_CMD_NAMES` below). Missing and
       unexpected names are reported separately, by name. `CMD_DEV_ADDRESS`
@@ -33,7 +32,7 @@ is_memory_cmd(uint8_t cmd)` definition and asserts BOTH:
 
 This is a genuinely-populated structural scan, NOT a hollow declared-empty
 detector -- the exact tech-debt fate this project incurred with v1.12's
-GATE-03 (a checker that could never fail because it asserted nothing
+a hollow checker (one that could never fail because it asserted nothing
 concrete). The paired pytest (`tests/test_check_is_memory_cmd_no_ifdef.py`)
 proves this checker actually flips to non-zero on a committed planted
 violation (`tests/fixtures/planted_ifdef_in_predicate.h`), injected via the
@@ -87,7 +86,7 @@ _DEFAULT_CMD_ADMISSION_SRC = os.path.join(
 
 # Env-override seam: lets the paired pytest point this checker at a
 # deliberately-violating fixture file (tests/fixtures/planted_ifdef_in_predicate.h)
-# without editing the real, clean firestarter.h (anti-hollow contract, D-04).
+# without editing the real, clean firestarter.h (anti-hollow contract).
 # This seam is FAIL-CLOSED: a path that does not exist is an ERROR, never a
 # silent pass -- see main() below.
 FIRESTARTER_CMD_ADMISSION_SRC = os.environ.get(
@@ -97,7 +96,7 @@ FIRESTARTER_CMD_ADMISSION_SRC = os.environ.get(
 # The predicate this gate reads.
 _PREDICATE_FUNC_NAME = "is_memory_cmd"
 
-# The frozen expected command set (D-02/D-04). Adding a memory command is a
+# The frozen expected command set. Adding a memory command is a
 # DELIBERATE act that must edit this line -- it is not auto-derived from the
 # header, because the whole point of this gate is to catch an
 # accidental/unreviewed enumeration drift, not just mirror it.
@@ -136,7 +135,7 @@ def _predicate_def_pattern() -> re.Pattern[str]:
     trailing `\\{` is what excludes a `;`-terminated forward declaration. The
     pattern deliberately pins `static inline` (not just any `bool` return):
     RESEARCH F-F makes header-inline placement load-bearing (a `.cpp`
-    definition would not link into any native test binary, so Plan 119-02's
+    definition would not link into any native test binary, so the native
     two-env truth-table suite could not exist), so a predicate that lost
     `static inline` would already be a regression this gate should refuse to
     silently accept as a match.
@@ -149,7 +148,7 @@ def _predicate_def_pattern() -> re.Pattern[str]:
 
 
 # Preprocessor conditional deny list: any of these directives inside the
-# predicate body defeats D-02's purpose, not only ones conditioned on
+# predicate body defeats the same purpose, not only ones conditioned on
 # DEV_TOOLS. A narrower check (e.g. matching only `#ifdef DEV_TOOLS`) would be
 # evadable by conditioning on a different macro instead, so every conditional
 # directive is checked, regardless of which macro (if any) it names.

--- a/tools/check_mypy_watermark.py
+++ b/tools/check_mypy_watermark.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""tools/check_mypy_watermark.py — CI mypy gate (D-10, Phase 37; hardened Phase 131 GATE-01..04).
+"""tools/check_mypy_watermark.py — CI mypy gate (GATE-01..04).
 
 Run mypy, count errors, fail if error count exceeds the watermark.
 Watermark is stored as a comment in [tool.mypy] in pyproject.toml:
@@ -26,7 +26,7 @@ Guard order (in `classify_mypy_result`) is load-bearing, mirroring
 `check_no_exists_proxy.py`'s never-vacuous-before-missing-target discipline:
 each guard is hoisted above the guard it would otherwise be vacuously
 satisfied by. Returncode is consulted BEFORE any error-count regex — this
-single reordering is GATE-01/GATE-02's fix. See `.planning/research/STACK.md`
+single reordering is GATE-01/GATE-02's fix. See
 §1e for the bug this replaces.
 """
 
@@ -36,14 +36,14 @@ import sys
 from pathlib import Path
 
 # Resolve the repo root from this file's location so the gate behaves
-# identically regardless of the caller's working directory (CR-WR-03).
+# identically regardless of the caller's working directory.
 # Layout: <repo>/tools/check_mypy_watermark.py -> repo root is two parents up.
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # GATE-03: a floor to be raised when the tree grows, never lowered to
 # accommodate a smaller run. If a legitimate deletion drops the tree below
 # it, lower it in the same commit as that deletion, with the new measured
-# number. Prior value: none -- first value, set by Phase 131 plan 131-01
+# number. Prior value: none -- this is the first value
 # from the measured 120 of the CI-replica run.
 MIN_CHECKED_SOURCE_FILES = 120
 
@@ -92,7 +92,7 @@ def get_watermark() -> int:
     """Read the mypy_error_watermark integer from pyproject.toml."""
     text = (REPO_ROOT / "pyproject.toml").read_text()
     # Anchor to a comment line (optional leading whitespace then '#') so the
-    # watermark is read from its declaration, not an incidental match (WR-04).
+    # watermark is read from its declaration, not an incidental match.
     m = re.search(r"^\s*#\s*mypy_error_watermark\s*=\s*(\d+)", text, flags=re.MULTILINE)
     if not m:
         print(
@@ -118,7 +118,7 @@ def mypy_argv() -> list[str]:
 def run_mypy() -> subprocess.CompletedProcess:
     """Thin runner: invoke mypy and return the raw CompletedProcess.
 
-    Deliberately no env-var seam overriding this argv (D-01): an env var
+    Deliberately no env-var seam overriding this argv: an env var
     that could swap which program runs here would be a bypass added to the
     one gate whose entire sin was being bypassable.
     """

--- a/tools/check_no_community_support_status_write.py
+++ b/tools/check_no_community_support_status_write.py
@@ -1,13 +1,13 @@
 """
 AST-based no-auto-graduate lock gate for the report/parse path (DISP-01,
-Phase 114 Plan 03).
+the community triage path).
 
 Scans `firestarter/diagnostic_report.py` (the Phase-110/112/114-01
 `DiagnosticReport`/`DbDiff` model) and `tools/parse_devtest_issue.py` (the
 Phase-114-02 INBOX-01 triage parser) and DENIES any WRITE of a chip's
-`support_status` -- the invariant this gate machine-enforces (D-01/D-02):
+`support_status` -- the invariant this gate machine-enforces:
 graduation is flag-only and human-gated, so NO code path that parses a
-community `dev test` report may ever write `support_status`. Per D-02, the
+community `dev test` report may ever write `support_status`. The
 report/parse path only ever READS `support_status` (via
 `EpromDatabase.get_eprom_config` / a plain dict `.get(...)`); the sole
 allowed write locus stays the human-authored `tools/build_db.py:714`
@@ -32,8 +32,8 @@ already READ from the DB) is likewise never flagged, because
 scoping the scan to the report/parse path only, rather than trying to
 whitelist by value, is what the RESEARCH's Pitfall 1 write-up recommends.
 
-Fail-closed (T-114-07, the v1.12 hollow-GATE-03 lesson): BOTH scan targets
-are mandatory here (unlike SAFE-03's optional third-leg tolerance) -- if
+Fail-closed (the hollow-checker lesson): BOTH scan targets
+are mandatory here (unlike the orchestrator gate's optional third leg) -- if
 EITHER is missing from disk, the gate fails closed rather than silently
 scanning only the file that happens to exist. A checker that quietly
 tolerates one missing target is exactly as hollow as scanning nothing.
@@ -44,10 +44,10 @@ This is a genuinely-populated AST walk (`ast.parse` + a fresh
 checker actually flips to non-zero on a planted violation, injected via the
 `FIRESTARTER_DISP01_REPORT` / `FIRESTARTER_DISP01_PARSER` env-overrides
 below (mirrors `tools/check_devtest_orchestrator.py`'s
-`FIRESTARTER_DEVTEST_SRC` seam) -- D-05's anti-hollow contract.
+`FIRESTARTER_DEVTEST_SRC` seam) -- the anti-hollow contract.
 
 Wired via `pytest tests/`, NOT a dedicated `.github/workflows/ci.yml` step
-(mirrors the SAFE-03 convention exactly) -- CI's existing
+(mirrors the orchestrator gate's convention exactly) -- CI's existing
 `pytest tests/ --cov-fail-under=70` step picks up the paired test
 automatically; adding a YAML step would double-run the gate.
 
@@ -74,7 +74,7 @@ _DEFAULT_DISP01_REPORT = os.path.join(
 # Env-override seam (mirrors check_devtest_orchestrator.py's
 # FIRESTARTER_DEVTEST_SRC): lets the paired pytest point this checker at a
 # deliberately-violating fixture file without editing the real, clean
-# diagnostic_report.py source (D-05).
+# diagnostic_report.py source.
 FIRESTARTER_DISP01_REPORT = os.environ.get(
     "FIRESTARTER_DISP01_REPORT", _DEFAULT_DISP01_REPORT
 )
@@ -91,7 +91,7 @@ FIRESTARTER_DISP01_PARSER = os.environ.get(
 )
 
 # ---------------------------------------------------------------------------
-# Deny vocabulary (D-02/D-05): the single write-target identifier.
+# Deny vocabulary: the single write-target identifier.
 # ---------------------------------------------------------------------------
 
 _SUPPORT_STATUS_KEY = "support_status"
@@ -170,7 +170,7 @@ def _scan_file(path: str) -> _SupportStatusWriteVisitor | None:
 
 
 def _assert_host_only(path: str) -> str | None:
-    """Assert `path` does not resolve into the firmware sub-repo (D-02).
+    """Assert `path` does not resolve into the firmware sub-repo.
 
     Returns an error string if the resolved path falls inside the sibling
     `firestarter/` firmware submodule (a peer of `firestarter_app/` in the
@@ -234,7 +234,7 @@ def main() -> None:
     if not scanned:
         # Defense in depth: the missing_targets guard above should already
         # have caught this, but a scanned-empty state must never vacuously
-        # pass regardless of how it was reached (D-05 anti-hollow contract).
+        # pass regardless of how it was reached (anti-hollow contract).
         print(
             "FAIL: no report/parse source files found to scan "
             f"(checked: {targets}) -- the gate cannot vacuously pass with "

--- a/tools/check_no_exists_proxy.py
+++ b/tools/check_no_exists_proxy.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""D-09's recurrence lint: forbids the module-level absence-proxy idiom from
-reappearing in this host test suite (Phase 123 Plan 09).
+"""Recurrence lint: forbids the module-level absence-proxy idiom from
+reappearing in this host test suite.
 
 **What this forbids, stated precisely.** A module-level assignment whose
 value is a boolean negation (`not ...`) of a path-existence call, or of a
 boolean combination of such calls -- the exact shape that made a firmware
 **rename** look like a firmware **absence** (RESEARCH's A-7 finding, the
-defect Phase 123 Plans 07/08 removed from all seven proxy-carrying modules).
+defect that was removed from all seven proxy-carrying modules).
 Uses the `ast` module, never a regex: an AST walk over module-level
 assignments looking for a unary `not` whose operand contains a call to an
 `exists` attribute anywhere in its subtree is precise, whereas a regex over
@@ -16,8 +16,8 @@ Both shapes are caught:
 
   - the simple shape: `FW_ABSENT = not some_path.exists()`
   - the compound shape: `FW_ABSENT = not (a.exists() and b.exists())` --
-    exactly what `tests/test_dispatch_mirror.py` used before its Phase 123
-    Plan 08 rekey onto `tests/fw_presence.py`.
+    exactly what `tests/test_dispatch_mirror.py` used before its rekey onto
+    `tests/fw_presence.py`.
 
 **What this must NOT forbid.** A path-existence check inside a FUNCTION
 BODY, used for ordinary control flow (e.g. `if not resolved.exists(): raise
@@ -82,7 +82,7 @@ instead).
 violating fixture, injected via the `FIRESTARTER_PROXY_LINT_TARGETS` seam
 above) -- the mandatory anti-hollow contract every source-scanning gate in
 this project carries, tracing back to the tech debt this project incurred
-with v1.12's GATE-03 (a checker that could never fail because it asserted
+with an earlier hollow gate (a checker that could never fail because it asserted
 nothing concrete).
 
 **Explicit non-claim (load-bearing).** A green run of this gate proves this
@@ -118,7 +118,7 @@ _APP_ROOT = os.path.dirname(_HERE)
 # ---------------------------------------------------------------------------
 # Explicit, non-pattern default target list -- see the module docstring's
 # "Explicit non-pattern default target list" section for the rationale.
-# Every top-level tests/*.py module as of Phase 123 Plan 09. tests/fixtures/
+# Every top-level tests/*.py module. tests/fixtures/
 # and tests/golden/ are subdirectories and are therefore never reachable from
 # this literal enumeration.
 # ---------------------------------------------------------------------------

--- a/tools/check_no_log_in_sdp_window.py
+++ b/tools/check_no_log_in_sdp_window.py
@@ -1,9 +1,8 @@
 """
 TRACE-03 third negative: structural scan proving no logging call sits inside
-the `0x0D` SDP command-sequence timing window (Phase 116 Plan 04, D-04 third
-bullet; window redefined by Phase 118 Plan 01, D-06).
+the `0x0D` SDP command-sequence timing window.
 
-**D-06 window redefinition.** Through Phase 117 this checker brace-matched
+**Window redefinition.** An earlier revision of this checker brace-matched
 `eeprom28c_write_init` and scanned the span *between* the command-emit call
 site and the completion-wait call site. That span never looks inside
 `eeprom28c_emit_command_sequence()` -- the function whose bare `set_data`
@@ -18,7 +17,7 @@ The window is now the union of two brace-matched function bodies:
   * `eeprom28c_wait_for_sdp_completion()` -- the completion poll that
     follows it.
 
-Phase 118's OBS-01 report lines legitimately sit in the OLD between-the-
+The observation report lines legitimately sit in the OLD between-the-
 call-sites span (before the emit call and after the wait call, inside
 `eeprom28c_write_init` but outside both bodies above) -- this rewrite is
 what makes that placement provably legitimate rather than merely convenient.
@@ -30,11 +29,11 @@ secondary rename-tripwire, not the window-resolution mechanism -- if a
 future refactor moves the emitter or the poll out of `write_init` entirely,
 this still fails closed instead of silently scanning nothing meaningful.
 
-**D-11: this checker keeps exactly ONE job -- the no-logging rule.** It does
+**This checker keeps exactly ONE job -- the no-logging rule.** It does
 NOT also assert that `AT28C_TBLC_MAX_US` is cited in a comment anywhere.
 `_strip_comments` below deliberately blanks comment spans before the
 deny-list scan runs, so a citation-presence check would need a second pass
-over uncleaned text -- and Phase 118's runtime t_BLC budget check (D-09) is
+over uncleaned text -- and the runtime t_BLC budget check is
 strictly stronger evidence that the constant is load-bearing than a comment
 citation would be. Do not add a citation scan here or in a sibling checker.
 
@@ -44,7 +43,7 @@ call sites appear in either one.
 
 This is a genuinely-populated structural scan, NOT a hollow declared-empty
 detector -- the exact tech-debt fate this project incurred with v1.12's
-GATE-03 (a checker that could never fail because it asserted nothing
+a hollow checker (one that could never fail because it asserted nothing
 concrete). The paired pytest (`tests/test_check_no_log_in_sdp_window.py`)
 proves this checker actually flips to non-zero on a committed planted
 violation (`tests/fixtures/planted_log_in_window.cpp`, re-planted inside the
@@ -59,7 +58,7 @@ window is resolved via brace-matched structural text extraction, never a
 bare substring grep: `eeprom_28c.cpp` carries prose comments describing this
 exact sequence and its timing (see this function's own docstring above, and
 the sibling checkers' anti-false-positive lessons recorded for Phase-109
-SAFE-02 and Phase-110), and a loose pattern would false-positive on comment
+the safety rules), and a loose pattern would false-positive on comment
 text mentioning a logging macro by name. Comment spans (`//` and `/* */`)
 are blanked out (length- and line-preserving) before the deny-list scan
 runs, so a comment mentioning a logging macro is never mistaken for a call
@@ -71,7 +70,7 @@ comment is now inside the scanned region.
 Fails closed on every degenerate input -- missing/unreadable source path,
 either target function not found (or not brace-balanced), or either
 `eeprom28c_write_init` anchor set matching zero times -- so a later rename
-(e.g. Phase 117's emitter replacement, or a future one) cannot silently
+(e.g. an emitter replacement, now or in future) cannot silently
 hollow this gate; each failure mode names the fix (add the new anchor/name)
 rather than silently passing.
 
@@ -99,10 +98,10 @@ _DEFAULT_SDP_SRC = os.path.join(
 
 # Env-override seam: lets the paired pytest point this checker at a
 # deliberately-violating fixture file (tests/fixtures/planted_log_in_window.cpp)
-# without editing the real, clean eeprom_28c.cpp (anti-hollow contract, D-04).
+# without editing the real, clean eeprom_28c.cpp (anti-hollow contract).
 FIRESTARTER_SDP_SRC = os.environ.get("FIRESTARTER_SDP_SRC", _DEFAULT_SDP_SRC)
 
-# The function whose body IS the real SDP inter-byte timing window (D-06).
+# The function whose body IS the real SDP inter-byte timing window.
 _EMITTER_FUNC_NAME = "eeprom28c_emit_command_sequence"
 # The function whose body is the completion poll that follows the emitter.
 _POLL_FUNC_NAME = "eeprom28c_wait_for_sdp_completion"
@@ -111,14 +110,14 @@ _POLL_FUNC_NAME = "eeprom28c_wait_for_sdp_completion"
 # function to compute the scanned span.
 _FUNC_NAME = "eeprom28c_write_init"
 
-# v1.22 Phase 119 Plan 04 (D-14): eeprom28c_emit_sdp_sequence_timed() -- the
+# eeprom28c_emit_sdp_sequence_timed() -- the
 # shared micros()-bracket-plus-report-pair helper both the SDP-disable
 # (eeprom28c_write_init / eeprom28c_sdp_unlock_execute) and the new SDP-enable
 # (eeprom28c_sdp_lock_execute) sequences call -- MUST NEVER be added as a
 # third scanned window (a third name in _EMITTER_FUNC_NAME/_POLL_FUNC_NAME,
 # or a third _find_function_body call in _resolve_windows/scan). That
 # helper's body contains LOG_ID / LOG_ID_U32 / LOG_WARN_ID_U32 calls BY
-# DESIGN (D-12/D-14) -- it is the report/measurement wrapper AROUND the
+# DESIGN -- it is the report/measurement wrapper AROUND the
 # emit call, not the timing window itself. The real inter-byte SDP timing
 # window this checker exists to protect remains exactly
 # eeprom28c_emit_command_sequence's body (_EMITTER_FUNC_NAME above), which
@@ -146,7 +145,7 @@ def _func_def_pattern(func_name: str) -> re.Pattern[str]:
 
     Two properties are load-bearing and must be preserved by any future
     edit: the leading `\\b` sits before `void`, so this still matches a
-    `static void ...` definition (both D-06 targets are `static`); and the
+    `static void ...` definition (both targets are `static`); and the
     trailing `\\{` is what excludes the `;`-terminated forward declarations
     a few lines above each definition in the real file. `[^)]*` tolerates
     any parameter list, including the emitter's three-argument signature.
@@ -157,11 +156,11 @@ def _func_def_pattern(func_name: str) -> re.Pattern[str]:
 # Command-emit anchors -- the call(s) that kick off the SDP command sequence,
 # used ONLY by the secondary write_init rename-tripwire in _resolve_windows,
 # not by window resolution itself. The first entry matched the pre-Phase-117
-# flash_execute_command(EEPROM_SDP_DISABLE) call site. Phase 117 (FIX-01)
+# flash_execute_command(EEPROM_SDP_DISABLE) call site. A later change
 # replaced that emitter with the 0x0D-local eeprom28c_emit_command_sequence()
 # driven through handle->firestarter_set_data, so the second entry matched
-# eeprom28c_write_init's direct call site through Phase 118. Phase 119 Plan 04
-# (D-14) factored a shared eeprom28c_emit_sdp_sequence_timed() helper that
+# eeprom28c_write_init's direct call site. A shared
+# eeprom28c_emit_sdp_sequence_timed() helper was then factored out, which
 # eeprom28c_write_init now calls instead of eeprom28c_emit_command_sequence
 # directly (the helper itself calls the emitter), so the third entry below is
 # what matches on today's tree. Per the anti-hollow contract this tuple is
@@ -174,7 +173,7 @@ _EMIT_ANCHOR_PATTERNS = (
     re.compile(
         r"eeprom28c_emit_command_sequence\s*\(\s*handle\s*,\s*EEPROM_SDP_DISABLE\b"
     ),
-    # v1.22 Phase 119 D-14: eeprom28c_write_init's call site is now the
+    # eeprom28c_write_init's call site is now the
     # shared timed-emit helper, not the emitter directly.
     re.compile(
         r"eeprom28c_emit_sdp_sequence_timed\s*\(\s*handle\s*,\s*EEPROM_SDP_DISABLE\b"
@@ -183,9 +182,9 @@ _EMIT_ANCHOR_PATTERNS = (
 
 # Completion-wait anchors -- same "secondary tripwire only" role as
 # _EMIT_ANCHOR_PATTERNS above. The first entry matched the pre-Phase-117
-# eeprom28c_wait_for_write( call site; Phase 117 deleted that function
-# outright (FIX-02 replaced its inverted read-back with an unconditional
-# t_WC wait plus a bounded DQ6 toggle poll, and FIX-06 split the page path
+# eeprom28c_wait_for_write( call site; that function was deleted
+# outright (its inverted read-back was replaced with an unconditional
+# t_WC wait plus a bounded DQ6 toggle poll, and the page path was split
 # into eeprom28c_wait_for_page_write), so the second entry is what matches
 # on today's tree. Same append-only anti-hollow contract as
 # _EMIT_ANCHOR_PATTERNS above.
@@ -201,8 +200,8 @@ _WAIT_ANCHOR_PATTERNS = (
 # LOG_OK_ID*, LOG_INIT_ID*, LOG_MAIN_ID*, LOG_END_ID*, LOG_DATA_ID*,
 # LOG_DEBUG_ID_SUB*) -- this single pattern matches every one of them without
 # needing to enumerate each macro name by hand. It also matches the bare
-# unconditional LOG_ID( / LOG_ID_U32( forms Phase 118's report lines use, so
-# no pattern change is needed for D-01's spelling to stay in coverage.
+# unconditional LOG_ID( / LOG_ID_U32( forms the report lines use, so
+# no pattern change is needed for that spelling to stay in coverage.
 _LOG_CALL_PATTERN = re.compile(r"\bLOG_[A-Z][A-Z0-9_]*\s*\(")
 
 
@@ -288,7 +287,7 @@ def _resolve_windows(
     cleaned_text: str,
 ) -> tuple[tuple[int, int], tuple[int, int]]:
     """Resolve the two function bodies that make up the SDP timing window
-    (D-06): the emitter body and the completion-poll body.
+: the emitter body and the completion-poll body.
 
     Also runs a secondary, rename-tripwire assertion: `eeprom28c_write_init`
     must still be brace-matchable and its body must still contain one
@@ -359,7 +358,7 @@ def scan(
     source_text: str,
 ) -> tuple[list[tuple[int, str]], tuple[int, int], tuple[int, int]]:
     """Resolve the SDP timing window (the emitter body plus the
-    completion-poll body, D-06) in `source_text` and scan both for
+    completion-poll body) in `source_text` and scan both for
     logging-macro call sites.
 
     Returns `(violations, emitter_range, poll_range)` on success, where

--- a/tools/check_protection_readability_invariants.py
+++ b/tools/check_protection_readability_invariants.py
@@ -1,6 +1,6 @@
 """
 GATE-02: AST invariant checker over
-`firestarter/protection_readability.py` (Phase 151, LOCK-01, D-05/D-06/D-12).
+`firestarter/protection_readability.py`.
 
 Scans exactly one target file, resolved via
 `FIRESTARTER_PROTECTION_READABILITY_SRC` (default: the real
@@ -17,7 +17,7 @@ resolves to the *checking phase's own directory* and a cross-phase reuse of
 the checker silently scans nothing and exits 0. `tools/` never moves
 relative to `firestarter/` when this gate is reused from a later phase.
 
-Plan 151-02 landed a three-axis, hand-curated table (readability,
+The module holds a three-axis, hand-curated table (readability,
 mechanism, permanence) sourced from `doc/lockable-proms.md`. Nothing
 structurally prevents a future edit from widening the curated readable-token
 set back into inference, or from adding a permit path not dominated by a
@@ -27,7 +27,7 @@ mechanically impossible to land unnoticed:
   Class 1 -- permit-by-default. State the concrete consequence: a permit
   reaching a family whose protection state is not readable would let a
   downstream layer render a state claim the silicon never supplied, which is
-  what LOCK-03 and LOCK-04 exist to prevent.
+  what this gate exists to prevent.
     (a) generalised from `check_sdp_capability_invariants.py`'s Class 1(a).
         That gate flags a `return` of a tuple literal whose first element is
         the constant `True`, only when undominated by a membership test.
@@ -39,7 +39,7 @@ mechanically impossible to land unnoticed:
         these two tokens must never be returned from this pure module at
         all, because `protection_gate_for_entry`'s signature accepts no
         device response -- there is no legitimate dominated case to exempt
-        (D-12 leg 4).
+        .
     (b) any bare exception handler (`except:` with no exception type)
         anywhere in the module, which could swallow a refusal-shaped error
         into a silent permit -- copied unchanged from the analog. This rule
@@ -70,7 +70,7 @@ mechanically impossible to land unnoticed:
 
   Class 3 -- the reporting axes, DELIBERATELY WEAKER. `MECHANISM_BY_TOKEN`
   and `PERMANENCE_BY_TOKEN` are literal dict displays consumed only by
-  prose and do not gate answering anywhere -- D-06 keys the read/refuse
+  prose and do not gate answering anywhere -- the read/refuse decision keys
   decision only on the readability axis (Class 2), never on mechanism or
   permanence. This rule is stated here, in words, as weaker by design: each
   of the two mappings is checked only for (i) exactly one module-level
@@ -86,10 +86,10 @@ mechanically impossible to land unnoticed:
   at least one key. An empty record would mean the C-17 documentation
   disagreement (`lockable-proms.md`'s bare `W29C020` vs. its own
   restatements) had been silently resolved away rather than recorded, which
-  is precisely what D-06 §5's tiebreak rule forbids.
+  is precisely what the tiebreak rule forbids.
 
 Anti-hollow contract (the discipline that closed this project's v1.12
-GATE-03 hollow-checker debt -- a checker that could never fail because it
+hollow-checker debt -- a checker that could never fail because it
 asserted nothing concrete): this is a genuinely-populated `ast.parse` +
 `ast.NodeVisitor` walk, never a declared-empty detector. It is paired with
 `tests/test_check_protection_readability.py`, which plants a REAL
@@ -145,8 +145,8 @@ _TOKEN_SET_NAMES: tuple[str, ...] = (
     "DOCUMENTED_NOT_READABLE_TOKENS",
 )
 
-# The two D-09 output classes that require a real silicon read and must
-# therefore be structurally unreachable from this pure module (D-12 leg 4).
+# The two output classes that require a real silicon read and must
+# therefore be structurally unreachable from this pure module.
 _SILICON_ONLY_TOKENS: frozenset[str] = frozenset({"protected", "unprotected"})
 
 # Class 2(c) method names that widen/mutate a frozenset in place.
@@ -197,7 +197,7 @@ class _SiliconOnlyReturnVisitor(ast.NodeVisitor):
     could reuse them), but `resolve()` flags every `permit_return`
     unconditionally, dominated or not: unlike the analog's `True`,
     `protected`/`unprotected` must never be returned from this pure module
-    at all, because its signature accepts no device response (D-12 leg 4).
+    at all, because its signature accepts no device response.
     """
 
     def __init__(self, filename: str) -> None:
@@ -388,7 +388,7 @@ def _is_literal_str_to_str_dict(value: ast.expr) -> bool:
     """Class 3's deliberately weaker shape check: `value` is an `ast.Dict`
     whose every key and every value is a string `Constant`. No dominance
     analysis, no key-provenance check against the curated token sets --
-    that weakening is intentional (D-06 keys answering only on readability,
+    that weakening is intentional (answering keys only on readability,
     never on mechanism or permanence) and is stated in this gate's module
     docstring."""
     if not isinstance(value, ast.Dict):

--- a/tools/check_sdp_capability_invariants.py
+++ b/tools/check_sdp_capability_invariants.py
@@ -1,6 +1,6 @@
 """
 GATE-01: AST invariant checker over `firestarter/sdp_capability.py`
-(Phase 121 Plan 03, D-14).
+.
 
 Scans exactly one target file, resolved via `FIRESTARTER_SDP_CAPABILITY_SRC`
 (default: the real `firestarter/sdp_capability.py`, mirrored by
@@ -8,7 +8,7 @@ Scans exactly one target file, resolved via `FIRESTARTER_SDP_CAPABILITY_SRC`
 `tools/check_devtest_orchestrator.py`'s `FIRESTARTER_DEVTEST_SRC` and
 `tools/check_is_memory_cmd_no_ifdef.py`'s `FIRESTARTER_CMD_ADMISSION_SRC`).
 
-Phase 120 derived a static, fail-closed, name-keyed SDP-capability partition
+The host derives a static, fail-closed, name-keyed SDP-capability partition
 (43 ALLOW / 41 REFUSE) from `infoic.xml`'s `INFOIC2PLUS` `flags` bit 15 and
 landed it as `SDP_CAPABLE_TOKENS`, a `frozenset` of string literals. Nothing
 structurally prevents a future edit from widening that allow-list back into
@@ -41,7 +41,7 @@ impossible to land unnoticed:
         or `|=` targeting `SDP_CAPABLE_TOKENS`, anywhere in the scanned file.
 
 Anti-hollow contract (the discipline that closed this project's v1.12
-GATE-03 hollow-checker debt -- a checker that could never fail because it
+hollow-checker debt -- a checker that could never fail because it
 asserted nothing concrete): this is a genuinely-populated `ast.parse` +
 `ast.NodeVisitor` walk, never a declared-empty detector. It is paired with
 `tests/test_check_sdp_capability.py`, which plants a REAL subprocess-level
@@ -80,7 +80,7 @@ _DEFAULT_SDP_CAPABILITY_SRC = os.path.join(
 
 # Env-override seam: lets the paired pytest point this checker at a
 # deliberately-violating fixture file without editing the real, clean
-# sdp_capability.py (D-14 anti-hollow contract). This seam is FAIL-CLOSED --
+# sdp_capability.py (anti-hollow contract). This seam is FAIL-CLOSED --
 # a path that does not exist is an ERROR, never a silent pass (see main()).
 FIRESTARTER_SDP_CAPABILITY_SRC = os.environ.get(
     "FIRESTARTER_SDP_CAPABILITY_SRC", _DEFAULT_SDP_CAPABILITY_SRC
@@ -118,7 +118,7 @@ class _PermitByDefaultVisitor(ast.NodeVisitor):
     Source-order tracking is done by collecting `(lineno, kind)` events
     across the WHOLE function subtree (comprehension `ifs` are `Compare`
     nodes too, so they are covered by the same generic walk) and then
-    resolving dominance with a single ascending-lineno scan, per D-14's
+    resolving dominance with a single ascending-lineno scan, per the
     "ordered walk ... then compare line numbers" instruction -- this avoids
     depending on `ast.walk`'s BFS traversal order, which is not source order.
     """
@@ -188,7 +188,7 @@ def _module_level_token_set_bindings(
     """Every top-level (module-body) statement that binds `SDP_CAPABLE_TOKENS`
     -- `Assign`, `AnnAssign`, or `AugAssign` -- in source order. An `AugAssign`
     counts as a second binding event: it rebinds the name, which is exactly
-    what "bound anywhere other than exactly once" (D-14 Class 2a) means."""
+    what "bound anywhere other than exactly once" means."""
     bindings: list[ast.Assign | ast.AnnAssign | ast.AugAssign] = []
     for stmt in tree.body:
         if isinstance(stmt, ast.Assign):
@@ -222,7 +222,7 @@ def _is_clean_frozenset_of_literals_call(value: ast.expr) -> bool:
     with exactly one positional argument, no keywords, and that argument a
     set/list/tuple display of string literals only -- rejects a
     comprehension, a generator expression, a call, or a bare `Name`
-    reference, per D-14."""
+    reference."""
     if not isinstance(value, ast.Call):
         return False
     if not (isinstance(value.func, ast.Name) and value.func.id == "frozenset"):

--- a/tools/derive_sdp_partition.py
+++ b/tools/derive_sdp_partition.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Reproducible, fetch-based independent re-derivation of the SDP-capability
-partition (PROV-04, Phase 136.1 Plan 02).
+partition.
 
 Pinned to minipro commit ``a8efaedc236c1d9718bd28299dfbb99536b010ff`` -- the
 same revision ``tools/build_db.py``'s ``MINIPRO_XML_URL`` fetches.
@@ -16,7 +16,7 @@ to ``build_db.py`` itself -- never imported by production code or by the
 pytest suite, and never wired into CI (CI must never depend on a live
 network fetch).
 
-Preserves Phase 120's exact token-matching rules verbatim (origin:
+Preserves the original token-matching rules verbatim (origin:
 ``.planning/phases/120-host-cli-surface-wire-emission-capability-refusal/
 120-derive-sdp-allowset.py``): key on the EXACT ``part_number`` token
 (comma-split, uppercased), strip ONLY the ``@PACKAGE`` suffix, do NOT strip
@@ -31,7 +31,7 @@ Independently cross-checks the freshly-derived partition against BOTH:
       production transcription predicate (imported from the installed
       package, never reimplemented), and
   (b) ``chip_database.json``'s own committed ``protect_on_after`` field
-      (Plan 136.1-01) -- read directly, mirroring
+      -- read directly, mirroring
       ``tests/test_sdp_db_invariant.py``'s
       ``_partition_from_protect_on_after_field`` selection logic,
       DUPLICATED here deliberately (this script must not import from
@@ -86,7 +86,7 @@ def _load_infoic_xml() -> str:
 
 def _build_token_index(xml_text: str) -> dict[str, set[int]]:
     """EXACT ``part_number`` token (comma-split, uppercased, ``@PACKAGE``
-    suffix stripped, parentheticals NOT stripped -- Phase 120 rule 1) ->
+    suffix stripped, parentheticals NOT stripped -- rule 1) ->
     set of ``flags`` ints seen for that token across every
     ``<database type="INFOIC2PLUS">`` ``<ic>`` entry."""
     root = ET.fromstring(xml_text)
@@ -225,7 +225,7 @@ def main() -> int:
         )
 
     # Comparison (b): chip_database.json's own committed protect_on_after
-    # field (Plan 136.1-01).
+    # field.
     field_allow: set[str] = set()
     for mfr, chip in selected:
         part_number = chip["part_number"]

--- a/tools/diff_db.py
+++ b/tools/diff_db.py
@@ -1,22 +1,22 @@
 """
-GATE-02: Per-chip diff of the regenerated chip_database.json against the
+Per-chip diff of the regenerated chip_database.json against the
 pinned pre-milestone baseline (chip_database.baseline.json, 744 chips,
-Phase 70 integrated output).
+integrated output).
 
 Loads both JSONs, builds composite-keyed indexes (one key per record, so
 duplicate part_numbers are never shadowed — CR-01), classifies every changed
-chip by a cited root-cause rule (grouped by cause per D-01), reports new chips
+chip by a cited root-cause rule (grouped by cause), reports new chips
 and any missing chips, and exits with the following codes:
 
 Exit codes:
   0 — all changed chips explained by a cited root-cause rule; N new chips
       confirmed (Rule 1 unblock); 0 chips missing from baseline.
   1 — at least one chip has an unexplained diff OR at least one chip present in
-      the baseline is absent from the current DB (D-03 BLOCK: investigate
+      the baseline is absent from the current DB (BLOCK: investigate
       build_db.py, correct the logic, re-regen, re-diff).
   2 — infrastructure error: a required input file could not be loaded or parsed
       (missing/malformed baseline or current DB). Distinct from 1 so a CI
-      consumer does not confuse a missing input with a real diff BLOCK (WR-04).
+      consumer does not confuse a missing input with a real diff BLOCK.
 """
 
 import copy
@@ -41,7 +41,7 @@ BASELINE_FILE = os.environ.get(
 
 # ---------------------------------------------------------------------------
 # Root-cause labels and their grouped rationale strings
-# Each string embeds a [VERIFIED: minipro ...] citation per Phase 56 D-05/D-06.
+# Each string embeds a [VERIFIED: minipro ...] citation.
 # Permalink base: https://gitlab.com/DavidGriffith/minipro/-/blob/a8efaedc/src/database.c
 # ---------------------------------------------------------------------------
 _RATIONALES = {
@@ -304,7 +304,7 @@ def _pn(key):
 # ---------------------------------------------------------------------------
 # Field paths each root-cause rule is allowed to "explain". A diff is only
 # fully explained when EVERY differing field path is claimed by the matched
-# rule(s) (WR-02). Anything outside these sets routes to "unexplained" (D-03).
+# rule(s). Anything outside these sets routes to "unexplained".
 #
 # electrical.type is a DERIVED field: build_db.py's Pass-2 protocol-aware
 # re-derivation recomputes electrical.type purely from the (possibly
@@ -396,7 +396,7 @@ def _diff_field_paths(bl_chip, cu_chip, prefix=()):
     Recurses into nested dicts so e.g. a change to electrical.vpp surfaces as
     ("electrical", "vpp"). Non-dict values (and lists) are compared by equality
     at their path. Used by _classify_diff to prove that every differing field is
-    attributable to a known rule (WR-02).
+    attributable to a known rule.
     """
     paths = set()
     keys = set(bl_chip) | set(cu_chip)
@@ -424,11 +424,11 @@ def _classify_diff(bl_chip, cu_chip):
       - (label, extra_paths): label is the primary root-cause rule; extra_paths
         is the (possibly empty) set of differing field paths NOT explained by
         that rule's allowed-field set. A non-empty extra_paths means a compound
-        change (WR-01) — the secondary deltas are surfaced by the caller, and if
+        change — the secondary deltas are surfaced by the caller, and if
         any of them is outside ALL known rules' field sets the chip is escalated
-        to unexplained (WR-02).
+        to unexplained.
       - (None, diff_paths): no rule matched at all — fully unexplained, the
-        caller treats this as a D-03 BLOCK.
+        caller treats this as a BLOCK.
 
     The COMBINED case (BUG2_AND_BUG3) MUST be tested before the single-bug
     buckets — chips with both timing and vcc/vdd changes (Pitfall 2 in
@@ -440,26 +440,26 @@ def _classify_diff(bl_chip, cu_chip):
       1. RULE_ALGO     — algorithm changed (primary dispatch key)
       2. BUG2_AND_BUG3 — timing + voltage changed (combined fix, precedes singles)
       3. BUG2_TIMING   — timing changed only
-      4. RULE_VCC_MARGIN_RAIL — Phase 148 DATA-01 margin-rail substitution: baseline
+      4. RULE_VCC_MARGIN_RAIL — margin-rail substitution: baseline
                          vcc_mv was the 4000 mV verify rail, current vcc_mv now equals
                          current vdd_mv (value-scoped, before BUG3_VCC_VDD — otherwise a
                          mover would be misattributed to the vcc/vdd label-swap rationale)
       5. BUG3_VCC_VDD  — voltage (vcc/vdd) changed only
-      6a. RC1_DIP32_27C020 — pinout changed to DIP32_27C020 (Phase 98 RC-1 fix; before SRAM_PINOUT)
+      6a. RC1_DIP32_27C020 — pinout changed to DIP32_27C020 (before SRAM_PINOUT)
       6b. SRAM_PINOUT  — pinout changed only (other pinout re-routes)
       7. RULE_PHASE84_RELABEL — only electrical.type changed, AND the chip is in
                          _PHASE84_RELABEL_PART_NUMBERS (cosmetic label-only correction;
                          scoped by part_number; MORE SPECIFIC than BUG_A_ETYPE so must
                          precede it — otherwise BUG_A_ETYPE would match first)
       7b. VARIANT_DECODE — only electrical.type changed to 'EEPROM' AND proto in
-                         {0x0D, 0x34} (Phase 86 consolidation: 5V-EEPROM-pinout proto-0x0D
+                         {0x0D, 0x34} (consolidation: 5V-EEPROM-pinout proto-0x0D
                          Flash/EEPROM->EEPROM + X88C64P proto-0x34 UV-EPROM->EEPROM;
                          scoped by new-type+proto so it does NOT shadow BUG_A_ETYPE)
       8. BUG_A_ETYPE   — electrical.type changed (flags-based EEPROM reclassification)
       9. BUG_B_VPP     — electrical.vpp/vpp_mv changed (0xF0-mask fix)
       10. RULE_PHASE66 — only support_status/unsupported_reason/vpp/vpp_mv changed
                          (LAST — least specific; must not shadow BUG_A_ETYPE/BUG_B_VPP)
-      -> None          — no rule matched (UNEXPLAINED = D-03 BLOCK)
+      -> None          — no rule matched (UNEXPLAINED = BLOCK)
     """
     bl_prog = bl_chip.get("programming", {})
     cu_prog = cu_chip.get("programming", {})
@@ -499,7 +499,7 @@ def _classify_diff(bl_chip, cu_chip):
         and not pinout_diff
         and not type_diff
     ):
-        # RULE_VCC_MARGIN_RAIL (before BUG3_VCC_VDD): Phase 148 DATA-01
+        # RULE_VCC_MARGIN_RAIL (before BUG3_VCC_VDD):
         # margin-rail substitution. Scoped on the DECODED VALUES themselves —
         # baseline vcc_mv was the 4000 mV TL866 verify-margin rail (mirrors
         # build_db.py's _VCC_MARGIN_RAIL_MV = VCC_VOLTAGES[0x02]); current
@@ -509,9 +509,9 @@ def _classify_diff(bl_chip, cu_chip):
         # compound change (algo/timing/pinout/type also differing) falls
         # through to a more generic rule instead of being silently absorbed.
         # Placed BEFORE BUG3_VCC_VDD: otherwise a mover whose only other delta
-        # is a secondary field would be misattributed to the Phase 57/58
+        # is a secondary field would be misattributed to the earlier
         # BUG-3 vcc/vdd label-swap rationale, which this substitution is not
-        # (D-01: the vcc/vdd labels are correct; only the margin-rail value
+        # (the vcc/vdd labels are correct; only the margin-rail value
         # is being substituted).
         label = "RULE_VCC_MARGIN_RAIL"
     elif voltage_diff and not timing_diff and not algo_diff:
@@ -525,7 +525,7 @@ def _classify_diff(bl_chip, cu_chip):
         and not vpp_diff
         and cu_chip.get("pinout") == "DIP32_27C020"
     ):
-        # RC1_DIP32_27C020 (before SRAM_PINOUT): Phase 98 RC-1 fix — 0x08 ≤256K chips
+        # RC1_DIP32_27C020 (before SRAM_PINOUT): 0x08 ≤256K chips
         # reassigned from DIP32_STD to DIP32_27C020. Scoped to the new pinout value so
         # SRAM_PINOUT (which handles 28-pin pm_idx=0 re-routes) is not masked.
         # Pinout-only scope is now ENFORCED here (not just asserted in
@@ -547,7 +547,7 @@ def _classify_diff(bl_chip, cu_chip):
         # decision). Placed before BUG_A_ETYPE so the part_number-scoped rule takes
         # priority for the named relabeled chips. The part_number check prevents this
         # rule from silently explaining accidental type drift on unrelated chips
-        # (D-40 requirement: no collateral change to chips sharing the same infoic flags).
+        # (no collateral change to chips sharing the same infoic flags).
         label = "RULE_PHASE84_RELABEL"
     elif (
         type_diff
@@ -558,7 +558,7 @@ def _classify_diff(bl_chip, cu_chip):
         and cu_elec.get("type") == "EEPROM"
         and cu_prog.get("algorithm") in (0x0D, 0x34)
     ):
-        # VARIANT_DECODE (before BUG_A_ETYPE): Phase 86 consolidation electrical.type
+        # VARIANT_DECODE (before BUG_A_ETYPE): consolidation electrical.type
         # delta. The new classify() emits 'EEPROM' for the 5V-EEPROM-pinout proto-0x0D
         # chips (were 'Flash/EEPROM') and for X88C64P proto-0x34 (was 'UV-EPROM').
         # Scoped to new-type=='EEPROM' AND proto in {0x0D, 0x34} so it does NOT shadow
@@ -588,7 +588,8 @@ def _classify_diff(bl_chip, cu_chip):
         and not voltage_diff
         and not pinout_diff
     ):
-        # RULE_PHASE66: only Phase 66 fields changed (support_status, unsupported_reason,
+        # RULE_PHASE66: only the support-status fields changed
+        # (support_status, unsupported_reason,
         # electrical.vpp, electrical.vpp_mv). Placed LAST so it does not shadow
         # BUG_A_ETYPE/BUG_B_VPP (Pitfall 7 in 70-RESEARCH.md).
         label = "RULE_PHASE66"
@@ -601,7 +602,7 @@ def _classify_diff(bl_chip, cu_chip):
         and not type_diff
         and not vpp_diff
     ):
-        # PGSZ_PAGE_SIZE: Phase 94 / CR-01 — only programming.page_size changed
+        # PGSZ_PAGE_SIZE — only programming.page_size changed
         # (datasheet-sourced per-chip page size added for W29C040=256 / W29C020=128).
         # No other field changes. Placed LAST (most specific scope: programming.page_size
         # only) to avoid shadowing any compound changes detected by prior rules.
@@ -621,7 +622,7 @@ def _classify_diff(bl_chip, cu_chip):
         and not vpp_diff
         and bl_prog.get("page_size") == cu_prog.get("page_size")
     ):
-        # PROV01_PROTECT_METADATA: Phase 136.1 PROV-01 — only the three new
+        # PROV01_PROTECT_METADATA — only the three new
         # protect_off_before/protect_on_after/infoic_page_size_raw keys changed
         # (added). No other field changes, including the curated page_size (kept
         # distinct from infoic_page_size_raw by the explicit page_size equality
@@ -643,7 +644,7 @@ def _classify_diff(bl_chip, cu_chip):
 
 
 # ---------------------------------------------------------------------------
-# Schema-normalizing comparator (Phase 148 D-11)
+# Schema-normalizing comparator
 # ---------------------------------------------------------------------------
 def _voltage_str_to_mv(value):
     """Parse a voltage string like "4V" or "3.3V" -> integer millivolts.
@@ -673,11 +674,11 @@ def _canonicalize_db(db):
     """Return a normalized copy of a chip database on the numeric schema.
 
     A pure-representation migration (string voltage/timing fields ->
-    numeric mv/us fields) must produce zero additional GATE-02 diff rows.
+    numeric mv/us fields) must produce zero additional diff rows.
     This function normalizes both the pre-migration string schema and the
     post-migration numeric schema to the same shape before comparison, so
     `_classify_diff`/`_diff_field_paths` always see one schema regardless of
-    which side of the migration either input database is on (D-11: the
+    which side of the migration either input database is on (the
     pinned baseline is never re-pinned).
 
     Per-chip normalization rules (electrical.* / programming.* blocks):
@@ -718,7 +719,7 @@ def _canonicalize_db(db):
 def _load_db(path, label):
     """Load a chip-database JSON, exiting 2 (infra error) on any load failure.
 
-    WR-04: a missing/malformed input is an infrastructure problem, NOT a diff
+    A missing/malformed input is an infrastructure problem, NOT a diff
     BLOCK — it must use a distinct exit code (2) so a CI consumer keying on the
     exit status does not misreport it as a real gate failure (exit 1).
     """
@@ -736,7 +737,7 @@ def main():
     cu_db = _load_db(DB_FILE, "current DB")
 
     # Canonicalize both databases to the numeric schema before any
-    # comparison, so GATE-02 classifies identically whether either side is on
+    # comparison, so the gate classifies identically whether either side is on
     # the old string schema or the new numeric schema.
     bl_db = _canonicalize_db(bl_db)
     cu_db = _canonicalize_db(cu_db)
@@ -748,7 +749,7 @@ def main():
     bl_total = _raw_total(bl_db)
     cu_total = _raw_total(cu_db)
 
-    # CR-01/IN-01: the composite-key index is strictly 1:1 with chip records.
+    # The composite-key index is strictly 1:1 with chip records.
     # Assert it so a future collision regression fails loudly here instead of
     # silently shadowing records (and so the printed header count matches what
     # was actually diffed).
@@ -762,8 +763,8 @@ def main():
     )
 
     # Union of every field path that SOME known rule can explain. Used to decide
-    # whether a compound change's secondary deltas are benign-but-known (WR-01,
-    # just surface them) or truly outside all rules (WR-02, escalate to
+    # whether a compound change's secondary deltas are benign-but-known (just
+    # surface them) or truly outside all rules (escalate to
     # unexplained).
     _all_rule_paths = set()
     for _paths in _RULE_FIELD_PATHS.values():
@@ -808,11 +809,11 @@ def main():
     total_changed = sum(len(v) for v in changed_by_cause.values())
 
     # -----------------------------------------------------------------------
-    # Report: grouped-by-cause (D-01) with embedded citations
+    # Report: grouped-by-cause with embedded citations
     # -----------------------------------------------------------------------
     print("=" * 72)
     print("GATE-02 Per-chip Diff Report")
-    # IN-01: index is now 1:1 with records, so the diffed key count equals the
+    # The index is 1:1 with records, so the diffed key count equals the
     # raw record count — print both to make the reconciliation explicit.
     print(f"  Baseline: {BASELINE_FILE}  ({bl_total} chips, {len(bl_idx)} diffed)")
     print(f"  Current:  {DB_FILE}  ({cu_total} chips, {len(cu_idx)} diffed)")
@@ -844,12 +845,12 @@ def main():
         print()
 
     # New chips fall into two explained categories:
-    #   (a) EXTRA_CHIPS_SUPPLEMENT (Phase 86 VAR-05 / D-10): records carrying the
+    #   (a) EXTRA_CHIPS_SUPPLEMENT: records carrying the
     #       source="non-upstream-supplement" marker (2516/2532). Their presence —
     #       with the cited source marker — IS the explanation (they are absent from
-    #       both infoic.xml and the OLD baseline because the re-pin is Plan 86-03).
+    #       both infoic.xml and the OLD baseline because of the re-pin).
     #   (b) Rule 1 unblock (DIP24_2816 + algo=0x0D): the original new-chip class.
-    # A new chip that is NEITHER is surfaced as a WARN (WR-03).
+    # A new chip that is NEITHER is surfaced as a WARN.
     supplement_new = [
         key
         for key in new_chips
@@ -905,7 +906,7 @@ def main():
         print()
 
     # -----------------------------------------------------------------------
-    # Gate: unexplained diffs or missing chips = D-03 BLOCK (exit 1)
+    # Gate: unexplained diffs or missing chips = BLOCK (exit 1)
     # -----------------------------------------------------------------------
     failures = list(unexplained) + missing_chips
     if failures:

--- a/tools/gen_sdp_bus_config.py
+++ b/tools/gen_sdp_bus_config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Firestarter v1.22 SDP bus_config ground truth codegen (TRACE-02 / D-08 / D-09 / D-11).
+SDP bus_config ground-truth codegen.
 
 Derives, validates and emits the `bus_config_t` ground truth the Phase-116 trace
 suites assert against, for five representative AT28C-family chips spanning the
@@ -16,7 +16,7 @@ programmer dict into `bus_config_t` fields exactly the way
 `firestarter/src/json_parser.c`'s `parse_bus_config` does. It never
 reimplements `convert_to_programmer` — a reimplementation is a second thing
 that can be wrong, and the whole point of this generator is that the trace
-ground truth is NOT a transcription (D-08).
+ground truth is NOT a transcription.
 
 Mirrors the established `tools/gen_validation_header.py` shape:
   - Validate-first: validate_rows() raises ValueError on any derivation
@@ -31,7 +31,7 @@ Exit codes:
        measured reference -- pinouts.json moved and the trace goldens are stale)
   2 -- a required chip or its pinout was not found in the chip database
 
-TRACE-02 / D-08 / D-09 / D-11 analog of HARN-02 / D-01.
+The same shape as the validation-header generator.
 """
 
 import argparse
@@ -60,7 +60,7 @@ _PINOUTS_DEFAULT = _APP_ROOT / "firestarter" / "data" / "pinouts.json"
 sys.path.insert(0, str(_APP_ROOT))
 
 # ===========================================================================
-# 2. REPRESENTATIVE CHIP SET (D-09)
+# 2. REPRESENTATIVE CHIP SET
 # ===========================================================================
 
 # One chip per 0x0D pinout, plus a second DIP32_28C512_EEPROM size band.
@@ -94,7 +94,7 @@ BANNER = (
 
 
 # ===========================================================================
-# 3. DERIVATION (D-08) -- mirrors src/json_parser.c's parse_bus_config exactly
+# 3. DERIVATION -- mirrors src/json_parser.c's parse_bus_config exactly
 # ===========================================================================
 
 
@@ -211,7 +211,7 @@ def validate_rows(rows: list) -> None:
     - derived matching_lines / rw_line / address_mask equal the independently
       measured reference values, in the fixed REPRESENTATIVE_CHIPS order
     - the two DIP32 rows (AT28C010, AT28C040) have byte-identical bus_config
-      (the D-09 premise)
+      (the premise)
     """
     if len(rows) != len(REPRESENTATIVE_CHIPS):
         raise ValueError(

--- a/tools/gen_test_image.py
+++ b/tools/gen_test_image.py
@@ -4,7 +4,7 @@ Deterministic full-size pseudo-random image generator for bench validation.
 Replaces the non-deterministic /dev/urandom approach from write_test.sh with a
 reproducible random.Random(seed) equivalent. A fixed (size_bytes, seed) pair
 always produces byte-identical output, enabling a trustworthy SHA-256 oracle for
-the A->B write-cycle proof (Phase 82 D-03/D-04).
+the A->B write-cycle proof.
 
 CLI usage:
     python tools/gen_test_image.py <size_bytes> <seed> <output_path>
@@ -16,7 +16,7 @@ CLI usage:
 Prints the SHA-256 hex digest of the generated image to stdout.  This is the
 oracle value to record in EVIDENCE.json as sha256_image_A / sha256_image_B.
 
-Storage convention (D-04):
+Storage convention:
     /tmp/firestarter_bench_p82/<chip>_img_A.bin  (seed=1)
     /tmp/firestarter_bench_p82/<chip>_img_B.bin  (seed=2)
 """

--- a/tools/gen_validation_header.py
+++ b/tools/gen_validation_header.py
@@ -2,7 +2,7 @@
 """
 Firestarter v1.13 validation matrix codegen.
 
-Reads tools/validation_matrix_spec.json (authored input, D-01) and emits a
+Reads tools/validation_matrix_spec.json (authored input) and emits a
 deterministic C++ header for the native Unity test suites:
 
   firestarter/test/native/avr/_shared/validation_matrix.h
@@ -19,7 +19,7 @@ Exit codes:
   1 — spec validation failed (schema error)
   2 — spec file not found
 
-HARN-02 / D-01 / LCAT-05 analog.
+The same shape as the SDP bus_config generator.
 """
 
 import argparse

--- a/tools/parse_devtest_issue.py
+++ b/tools/parse_devtest_issue.py
@@ -4,11 +4,11 @@ Copyright (c) 2024 Henrik Olsson
 
 Permission is hereby granted under MIT license.
 
-INBOX-01 Community `dev test` Issue Triage Parser (v1.21 Phase 114)
+Community `dev test` Issue Triage Parser
 
 Stdlib-only CLI a maintainer runs during `gsd-inbox` triage against a
 community `dev test` GitHub issue. It does NOT edit the installed
-`.claude/gsd-core/workflows/inbox.md` (D-04) -- that workflow's job is
+`.claude/gsd-core/workflows/inbox.md` -- that workflow's job is
 fetching/labeling issues; this module's job is understanding the ONE
 issue shape `firestarter/submit.py` produces and is INVOKED standalone,
 e.g.:
@@ -17,7 +17,7 @@ e.g.:
     gh issue view <n> --json body  -q .body    # feed to --body-file/stdin
     python tools/parse_devtest_issue.py --title "$TITLE" --body-file body.txt
 
-Detection (D-04) requires BOTH markers, defensive against a stray fenced
+Detection requires BOTH markers, defensive against a stray fenced
 block anywhere else in an issue: the `[dev test]` title marker
 (`submit.py:build_title`) AND a fenced ```json block whose parsed object
 carries a `schema_version` key (`diagnostic_report.py:to_json_block`).
@@ -33,13 +33,13 @@ into a command, bounds the body size before parsing, and wraps every
 fails SOFT (returns `None` / skips the body) -- it never raises out to
 the caller.
 
-Cross-report agreement (GRAD-01, D-03): `count_agreeing` groups SAVED
+Cross-report agreement: `count_agreeing` groups SAVED
 issue bodies by their ALREADY-EMBEDDED `dedup_fingerprint`
 (`diagnostic_report.py:dedup_fingerprint`, never re-hashed here). This is
 the cross-report N>=2 human-decision signal -- explicitly distinct from
 Phase-108's internal per-run N>=2 (a single sweep's own repeat-run
 agreement). Nothing in this module writes `support_status`; it is a
-DISP-01 scan target (Plan 03) and is read-only by construction, matching
+a scan target and is read-only by construction, matching
 `diagnostic_report.py`'s own `db.get_eprom_config` read-only discipline.
 """
 
@@ -53,7 +53,7 @@ from pathlib import Path
 from typing import Any
 
 # ---------------------------------------------------------------------------
-# Module constants (D-04) -- the two detection markers + a defensive size bound
+# Module constants -- the two detection markers + a defensive size bound
 # ---------------------------------------------------------------------------
 
 _DEV_TEST_MARKER = "[dev test]"
@@ -70,7 +70,7 @@ _MAX_BODY_BYTES = 131_072
 
 
 # ---------------------------------------------------------------------------
-# Detection + defensive extraction (D-04)
+# Detection + defensive extraction
 # ---------------------------------------------------------------------------
 
 
@@ -102,7 +102,7 @@ def _extract_fenced_report(body: str | None) -> dict[str, Any] | None:
 
 
 def parse_devtest_body(title: str | None, body: str | None) -> dict[str, Any] | None:
-    """Both markers required (D-04): `[dev test]` in `title` AND a fenced
+    """Both markers required: `[dev test]` in `title` AND a fenced
     ```json block in `body` whose parsed object carries `schema_version`.
 
     Returns the parsed report dict, or `None` when either marker is
@@ -115,13 +115,13 @@ def parse_devtest_body(title: str | None, body: str | None) -> dict[str, Any] | 
 
 
 # ---------------------------------------------------------------------------
-# DB-diff surface (RPT-05 consumer) -- current-vs-proposed + ladder_state
+# DB-diff surface -- current-vs-proposed + ladder_state
 # ---------------------------------------------------------------------------
 
 
 def extract_db_diff(report_obj: dict[str, Any]) -> dict[str, Any]:
     """Read-only current-vs-proposed DB-diff surface from an already-parsed
-    report dict (defensive `.get` throughout, D-01/D-02).
+    report dict (defensive `.get` throughout).
 
     Tolerant of a missing `db_diff` (`None`, an older/degenerate report)
     and of a missing `ladder_state` key (schema 1.0, pre-Phase-114) --
@@ -157,13 +157,13 @@ def _read_live_support_status(chip: str | None) -> str | None:
 
 
 # ---------------------------------------------------------------------------
-# Cross-report N-agreeing (GRAD-01, D-03) -- dedup_fingerprint grouping ONLY
+# Cross-report N-agreeing -- dedup_fingerprint grouping ONLY
 # ---------------------------------------------------------------------------
 
 
 def count_agreeing(bodies: list[str]) -> dict[str, int]:
     """Group SAVED issue bodies by their embedded `dedup_fingerprint` and
-    return `{fingerprint: count}` (D-03, GRAD-01's cross-report N>=2 signal).
+    return `{fingerprint: count}` (the cross-report N>=2 signal).
 
     Reuses the ALREADY-EMBEDDED `dedup_fingerprint` from each body's fenced
     JSON -- never re-hashes and never reads a per-step run count (that
@@ -185,10 +185,10 @@ def count_agreeing(bodies: list[str]) -> dict[str, int]:
 
 
 # ---------------------------------------------------------------------------
-# Rendering (plain-text; no third-party dependency, D-04)
+# Rendering (plain-text; no third-party dependency)
 # ---------------------------------------------------------------------------
 
-# Literal #2 of three (D-11, v1.32 Phase 147 plan 147-05). Identical in
+# Literal #2 of three. Identical in
 # VALUE to `firestarter/diagnostic_report.py`'s `NOT_REPORTED`, but defined
 # separately here rather than imported: this module is a stdlib-only CLI
 # (module docstring above, `:9-11`) whose module-level imports are exactly
@@ -260,20 +260,20 @@ def render_diff(
     *,
     n_agreeing: int | None = None,
 ) -> str:
-    """Plain-text current-vs-proposed DB-diff render (D-04, no third-party
+    """Plain-text current-vs-proposed DB-diff render (no third-party
     import). Explicitly labels any `n_agreeing` value a maintainer decision
-    input, never an auto-promotion trigger (D-01).
+    input, never an auto-promotion trigger.
 
     Also carries the provenance identity a triager needs before any
     firmware-version claim can rest on this report (PROV-06): a labelled
     `host_version` row and a labelled `fw_board_identity` row that folds in
-    the `_NOT_ATTRIBUTABLE` clause when the identity is absent (D-14). No
-    `hw_revision` row (D-15) -- a write-path finding is attributable only
+    the `_NOT_ATTRIBUTABLE` clause when the identity is absent. No
+    `hw_revision` row -- a write-path finding is attributable only
     when host AND firmware are both known, and `hw_revision` is a coarse
     silkscreen bucket that cannot discriminate the operator's Rev 2.2 /
     Rev 2.0 / modified Rev 0 boards, so a line naming it would look
     authoritative while answering nothing. No derived `attributable`
-    boolean either (D-14) -- dead data with no consumer.
+    boolean either -- dead data with no consumer.
     """
     auto_capture = report_obj.get("auto_capture") or {}
     chip = auto_capture.get("chip", "?")
@@ -282,7 +282,7 @@ def render_diff(
     # coalescing expression -- such an expression also fires on other falsy
     # values with no decision behind them, and a community-authored body can
     # genuinely carry `""`, which must render the marker, never a blank
-    # (mirrors `diagnostic_report.py`'s `_identity_cell`, D-10/D-11/D-12).
+    # (mirrors `diagnostic_report.py`'s `_identity_cell`).
     host_version = auto_capture.get("host_version")
     host_version_cell = (
         NOT_REPORTED
@@ -318,7 +318,7 @@ def render_diff(
 
 
 # ---------------------------------------------------------------------------
-# CLI (argparse, stdlib-only, D-04)
+# CLI (argparse, stdlib-only)
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Removes the GSD planning vocabulary (`Phase NNN`, `D-NN`, `REQ-NN`, `TRAP #N`, `LEG-NN`, …) from `firestarter/` and `tools/`. Operator hard rule, restated 2026-08-29: process commentary does not belong in product source.

Three commits, split so each can be reviewed on its own.

## 1. User-facing surfaces (`7126083`)

The leak was not confined to comments. Three surfaces were printing planning vocabulary at people with no way to resolve it.

**CLI help text.** Click renders a command's docstring verbatim as its `--help` body, so `firestarter write --help` was printing this to end users:

```
TRAP #3 / D-13.3: ``--no-blank-check`` uses ``is_flag=True, ...
Phase 92 decouple: ``-b`` now skips ONLY the blank check. ...
Phase 153 (ERASE-01/ERASE-02): since this phase, ...
TRAP #6 / D-17/D-18 (v1.22 HOST-02): ``--skip-sdp-unlock`` is exposed ...
```

Eight command docstrings rewritten as help text that answers *what the flag does* instead of *which decision produced it*. `write` went 60 lines → 25 and now leads with the blank-check/erase split, which is the thing users actually get wrong. No documented behaviour was dropped — flag semantics, the 0x0D/0x05 no-op, the 1..65535 pulse bound and the 0x0B refusal above 50000 all survive in plain words.

**Option help.** `--no-progress` advertised `(D-11)`; `--force` advertised `(D-07)`.

**Report strings.** `dev test` reports carried `'write_scope="none": write omitted (D-01)'` and `"N cycles disagreed on outcome (D-06 marginal policy)"`; fault-injection logs were headed `# XACT-02`. These land in community issue reports.

19 string literals cleaned, 0 remain.

## 2. Package comments and docstrings (`dddde47`)

184 sites across 21 files, rewritten by hand — identifiers go, technical content stays. `"D-06: read-step disagreement across runs is a byte-level divergence metric"` keeps every word after the label. `"This is the host mirror of Phase 119 D-06/D-07's generic op-layer NULL-main refusal"` becomes `"the host mirror of the firmware's generic op-layer NULL-main refusal"` — which is what the sentence was trying to say, now without a lookup table.

## 3. tools/ (`d56424e`)

232 sites across 19 files. Does not ship in the pip package (`packages = ["firestarter"]`), so nothing here reached an install; swept because it is source people read.

## What was deliberately left in place

- **8 sites in `serial_comm.py`** (`:410`, `:419`–`:515`). `_read_and_parse_lines` is ring-fenced as the v1.9 read-bug RCA baseline with its body digest-pinned. A docstring rewrap changed the digest; restored byte-exact. Stays until v1.9 opens the fence.
- **`BENCH-01..06` / `DEFECT-COV-NN`** in `audit_coverage_matrix.py` — that tool's own data model, minted and re-read from a ledger.
- **`GATE-01..04`** in the mypy watermark and invariant checkers — operational names printed in CI output, which need to match the checker that emitted them.
- **`audit_coverage_matrix.py`'s output strings.** These render a committed 186 KB evidence artifact (`tests/golden/v1.3-COVERAGE-MATRIX.md`) pinned byte-identical by `test_golden_file_matches`. Rewriting them means regenerating that golden — mutating a recorded v1.3 evidence document for cosmetic reasons. The golden is untouched.

## One gate had to change

`test_py32_packaging` **required** the literal strings `"D-17"` and `"HOST-01"` to be present in `firmware.py` — a test mandating provenance in source. Those two identifiers were removed from its phrase list. The gate's purpose is unaffected: `"accepted deviation"` plus the 25-line proximity check to `def flash_method(` still stop the record drifting, and the fail-closed planted-file leg still passes.

## Still out of scope

`tests/` (~1774 sites) is a **separate decision, not more of the same work**: test files use phase identifiers as gate anchors and several tests *assert* on them, so stripping there changes gate behaviour rather than just hygiene.

## Verification

- **1976 passed, 32 snapshots** — identical to the pre-change baseline, after every tranche
- 6 snapshots updated in `test_characterization.ambr`; none added or removed; no golden regenerated
- `ruff check` and `ruff format --check` clean on `firestarter/` (the 4 errors in `tools/` are pre-existing at `beta` and unlinted by CI)
- Python 3.11, matching CI rather than the devcontainer's 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)